### PR TITLE
Fix the notation in the model and initialization documentation

### DIFF
--- a/docs/src/charged_particle_3d.md
+++ b/docs/src/charged_particle_3d.md
@@ -13,13 +13,13 @@ where ``m`` and ``e`` denote the particle's mass and charge, respectively.
 
 The canonical form of the equations can be obtained from the Hamiltonian
 ```math
-H (x,p) = \frac{1}{2m} (p-A(x))^2 + e \phi(x),
+H (x,p) = \frac{1}{2m} (p - e A(x))^2 + e \phi(x),
 ```
 as
 ```math
 \begin{aligned}
-\dot{x} (t) &= \frac{\partial H}{\partial p} (x(t),p(t)) = \frac{1}{m} (p(t) - A(x(t))), \\
-\dot{p} (t) &= - \frac{\partial H}{\partial x} (x(t),p(t)) = \frac{1}{m} \nabla A(x(t)) \cdot (p(t)-A(x(t))) - \nabla \phi(x(t)) ,
+\dot{x} (t) &= \frac{\partial H}{\partial p} (x(t),p(t)) = \frac{1}{m} (p(t) - e A(x(t))), \\
+\dot{p} (t) &= - \frac{\partial H}{\partial x} (x(t),p(t)) = \frac{e}{m} \nabla A(x(t)) \cdot (p(t) - e A(x(t))) - e \nabla \phi(x(t)) ,
 \end{aligned}
 ```
 where the fields ``(E,B)`` are related to the potentials ``(\phi, A)`` by

--- a/docs/src/guiding_center_4d.md
+++ b/docs/src/guiding_center_4d.md
@@ -10,7 +10,7 @@ The dynamics of the guiding centre can be described in terms of only four coordi
 The simplest form of the guiding centre equations can be obtained from the Lagrangian
 ```math
 \begin{aligned}
-L &= (A (r) + u b (r)) \cdot \dot{r} - H(r,u) , &
+L &= \left( A (r) + u b (r) \right) \cdot \dot{r} - H(r,u) , &
 H &= \tfrac{1}{2} u^{2} + \mu \vert B (r) \vert ,
 \end{aligned}
 ```

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -29,14 +29,14 @@ Set $e = e' \hat{e}$ with $e' = 1.602 176 634 \cdot 10^{-19}$ and $\hat{e} = \ma
 The absolute value of the velocity is obtained from the particle energy by $\vert v \vert^2 = 2 W / m$.
 In normalised units, we have $W = W' \hat{W}$ and $v = v' \hat{v}$ where $\hat{W} = e \mathrm{V}$ and $\hat{v} = \hat{l} \hat{\omega}_c = \hat{l} \hat{B} e / m$.
 
-Let us compute the normalise kinetic energy,
+Let us compute the normalised kinetic energy,
 ```math
 \frac{\vert v' \vert^2}{2}
 = \frac{W' \hat{W}}{m \hat{v}^2}
 = \frac{W' e \mathrm{V} m^2}{m \hat{l}^2 \hat{B}^2 e^2} .
 ```
 
-Usually, we have $\hat{B} = T = \mathrm{kg} / \mathrm{C} \mathrm{s}$. Recall that $\mathrm{V} = \mathrm{kg} \mathrm{m}^2 / \mathrm{C} \mathrm{s}^2$ and let us set $\hat{l} = l_0 \mathrm{m}$, then
+Usually, we have $\hat{B} = T = \mathrm{kg} / \mathrm{C}\,\mathrm{s}$. Recall that $\mathrm{V} = \mathrm{kg}\,\mathrm{m}^2 / \mathrm{C}\,\mathrm{s}^2$ and let us set $\hat{l} = l_0 \mathrm{m}$, then
 ```math
 \frac{\vert v' \vert^2}{2} = \frac{m' W'}{e' l_0^2} .
 ```
@@ -65,12 +65,25 @@ and accordingly
 \end{aligned}
 ```
 
-The ElectromagneticFields.jl package provides three functions `a⃗(t,x)`, `b⃗(t,x)`, `c⃗(t,x)` that can be used to construct the velocity vector $v$.
-The function `b⃗` returns the unit vector of the magnetic field, thus
+For each equilibrium, the ElectromagneticFields.jl package generates an orthonormal triad
+$(a, b, c)$, where $b$ is the unit vector of the magnetic field and $a$ and $c$ span the plane
+perpendicular to it.
+The triad is exposed in three different component representations, which coincide only in
+Cartesian coordinates:
+
+| Functions | Components |
+| ------------------------------ | ---------------- |
+| `a(t,x)`, `b(t,x)`, `c(t,x)` | covariant |
+| `aₚ(t,x)`, `bₚ(t,x)`, `cₚ(t,x)` | physical |
+| `a⃗(t,x)`, `b⃗(t,x)`, `c⃗(t,x)` | contravariant |
+
+The velocity vector $v$ is assembled in physical coordinates, that is from `aₚ`, `bₚ` and `cₚ`, and
+subsequently transformed to contravariant coordinates with the inverse Jacobian `DF̄`.
+The function `bₚ` returns the unit vector of the magnetic field, thus
 ```math
 v_{\parallel}' = \vert v' \vert \, \sqrt{1 - \sin \alpha} \, b .
 ```
-The functions `a⃗` and `c⃗` return two unit vectors that span the plane perpendicular to the magnetic field, thus
+The functions `aₚ` and `cₚ` return two unit vectors that span the plane perpendicular to the magnetic field, thus
 ```math
 v_{\perp}' = \vert v' \vert \, \sqrt{\sin \alpha} \, ( - a \, \sin \theta - c \, \cos \theta ) ,
 ```
@@ -85,9 +98,10 @@ The magnetic moment is computed as
 
 In order to compute the particle position, we need to construct the gyro radius vector $\rho$, which is given by
 ```math
-\rho = \frac{b \times v}{\omega_c} = \frac{b \times \hat{v} v'}{\hat{\omega_c} \omega_c'}  = l_{0} \, \frac{b \times v'}{\vert B' \vert} .
+\rho = \frac{b \times v}{\omega_c} = \frac{b \times \hat{v} v'}{\hat{\omega}_c \omega_c'}  = \hat{l} \, \frac{b \times v'}{\vert B' \vert} .
 ```
-Note that 
+Here we used $\hat{v} / \hat{\omega}_c = \hat{l}$, which follows from $\hat{v} = \hat{l} \hat{\omega}_c$, and recall that $\hat{l} = l_0 \mathrm{m}$.
+Note that
 ```math
 \omega_c
 = \frac{e \vert B \vert}{m}
@@ -105,7 +119,7 @@ so that
 ```
 The normalized gyro radius vector reads
 ```math
-\rho' = \frac{\rho}{l_0} = \frac{b \times v'}{\vert B' \vert} ,
+\rho' = \frac{\rho}{\hat{l}} = \frac{b \times v'}{\vert B' \vert} ,
 ```
 so that the normalised particle position is
 ```math
@@ -133,8 +147,8 @@ and the total velocity by
 With that, we can compute the perpendicular and total energy,
 ```math
 \begin{aligned}
-W_{\perp}' &= \frac{e l₀^2 \vert v_\perp \vert^2}{2m} , \qquad
-W' &= \frac{e l₀^2 \vert v \vert^2}{2m} .
+W_{\perp}' &= \frac{e l_0^2 \vert v_\perp \vert^2}{2m} , \qquad
+W' &= \frac{e l_0^2 \vert v \vert^2}{2m} .
 \end{aligned}
 ```
 The pitch angle is obtained as

--- a/docs/src/normalization.md
+++ b/docs/src/normalization.md
@@ -10,7 +10,7 @@ the guiding center system.
 
 Consider the phasespace Lagrangian
 ```math
-L (q, \dot{q}, v) = ( mv + A (x) ) \cdot \dot{x}  - \frac{m}{2} \vert v \vert^2  - e \phi (x) ,
+L (q, \dot{q}, v) = ( mv + e A (x) ) \cdot \dot{x}  - \frac{m}{2} \vert v \vert^2  - e \phi (x) ,
 ```
 
 and, in full generality, introduce the following normalizations:
@@ -38,7 +38,7 @@ Let us choose the following normalizations (and note that others are possible an
 \hat{L} &= m \hat{v}^2 = e \hat{\phi} ,
 \end{aligned}
 ```
-with the characteristic length $l$.
+with the characteristic length $\hat{l}$.
 The normalized Lagrangian becomes
 ```math
 L' = \bigg( \frac{\hat{x}}{\hat{t} \hat{v}} \, v' + \underbrace{\frac{e \hat{B}}{m}}_{\hat{\omega}_c} \frac{\hat{x} \hat{l}}{ \hat{t} \hat{v}^2} \, A' \bigg) \cdot \dot{x}' - \frac{\vert v' \vert^2}{2} - \phi' ,
@@ -86,11 +86,11 @@ where $\hat{\rho}_{\mathrm{th}}$ is the characteristic gyro radius, and the norm
 ```math
 L' = \bigg( v' + \frac{\hat{l}}{\hat{\rho}_{\mathrm{th}}} \, A' \bigg) \cdot \dot{x}' - \frac{\vert v' \vert^2}{2} - \frac{e \hat{\phi}}{m v_{\mathrm{th}}^2} \phi' .
 ```
-This leaves room for different orderings and consequently different normalizations. 
+This leaves room for different orderings and consequently different normalizations.
 For example, in drift kinetics, we have $\hat{\rho}_{\mathrm{th}} / \hat{l} \sim \epsilon$ and $e \hat{\phi} / m v_{\mathrm{th}}^2 \sim 1$, while in gyro kinetics, we have $\hat{\rho}_{\mathrm{th}} / \hat{l} \sim 1$ and $e \hat{\phi} / m v_{\mathrm{th}}^2 \sim \epsilon$.
 
 !!! note "This section is for reference"
     No model in this package exposes the two prefactors $\hat{l} / \hat{\rho}_{\mathrm{th}}$ and
     $e \hat{\phi} / m v_{\mathrm{th}}^{2}$. Every model implements the first normalization above,
     with $\hat{v} = \hat{l} \hat{\omega}_{c}$ and both prefactors equal to one; the ε-ordered form
-    is recorded here for reference, not as something that can currently be selected. 
+    is recorded here for reference, not as something that can currently be selected.

--- a/src/utils/initial_conditions.jl
+++ b/src/utils/initial_conditions.jl
@@ -65,8 +65,8 @@ Compute initial conditions from the following arguments:
 * `E`: energy
 * `M`: mass
 * `C`: charge number
-* `a`, b, c: magnetic field unit vectors in physical coordinates
-* `b`: magnetic field unit vector in contravariant coordinates
+* `aₚ`, `bₚ`, `cₚ`: magnetic field unit vectors in physical coordinates
+* `b⃗`: magnetic field unit vector in contravariant coordinates
 * `B`: amplitude of magnetic field
 * `g̅`: inverse metric coefficients
 * `DF̄`: inverse Jacobian matrix
@@ -114,8 +114,8 @@ Compute initial conditions from the following arguments:
 * `μ`: magnetic moment
 * `M`: mass
 * `C`: charge number
-* `a`, b, c: magnetic field unit vectors in physical coordinates
-* `b`: magnetic field unit vector in contravariant coordinates
+* `aₚ`, `bₚ`, `cₚ`: magnetic field unit vectors in physical coordinates
+* `b⃗`: magnetic field unit vector in contravariant coordinates
 * `B`: amplitude of magnetic field
 * `g̅`: inverse metric coefficients
 * `DF̄`: inverse Jacobian matrix


### PR DESCRIPTION
Applies the accepted parts of #34 by @henry2004y, which could not be merged directly because it targets a July 2025 base and `docs/src/initialization.md` has since changed. Adds a few related corrections found while reviewing it.

### From #34

- Restore the charge factor in the canonical charged particle Hamiltonian, `H = (p - eA)²/2m + eφ`, and in the equations of motion derived from it. The `e` was missing in front of the vector potential, contradicting the noncanonical Lagrangian `L = (eA + mv)·ẋ` stated a few lines below.
- "normalise" → "normalised", thin spaces between unit symbols, `l₀^2` → `l_0^2` (a stray Unicode subscript inside a math block), `$l$` → `$\hat{l}$` for the characteristic length, and matched parenthesis heights in the guiding centre Lagrangian.

### Declined from #34

- "phasespace" → "phase space". The spelling is intentionally one word here.
- ``a⃗``/``b⃗``/``c⃗`` → ``a``/``b``/``c``. Both families exist in ElectromagneticFields and denote different objects; see the review on #34.

### Additional corrections

- `docs/src/normalization.md` had the same missing charge factor in the charged particle Lagrangian.
- The description of the field unit vectors on the initialization page was wrong even before #34. ElectromagneticFields generates the orthonormal triad in three component representations — covariant ``a``, ``b``, ``c``, physical ``aₚ``, ``bₚ``, ``cₚ`` and contravariant ``a⃗``, ``b⃗``, ``c⃗`` — which coincide only in Cartesian coordinates. `InitialConditions` assembles the velocity from the physical vectors and uses the contravariant ``b⃗`` only for the gyro radius cross product, as the example on the same page already showed. The prose and the `InitialConditions`/`InitialConditionsGC` docstrings now say so, and the docstrings no longer carry a duplicated `b` bullet.
- The gyro radius vector used `l_0` where it meant `\hat{l}`; `l_0` is the dimensionless measure of `\hat{l}` in metres. Also `\hat{\omega_c}` → `\hat{\omega}_c`.

Documentation only, apart from two docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
