### PR TITLE
All three constraint formulations for the 3D guiding centre model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,12 @@ deprecation shims; see *Changed* below for the mapping.
   equilibrium modules now mean the paper's ``g^1``, ``g^2`` rather than the two members of the one
   hard-coded pair, which were ``g^3`` and ``g^1``. Anything that read `c.g₁`/`c.g₂` still reads a
   constraint that vanishes along the flow, but not the same one.
+
+  In the same vein, `λₒ(t, q, p)`, `λ₁(t, q, p, params)` and `λ₂(t, q, p, params)` — the short forms
+  the scripts in `scripts/` use — take the constraint pair as a trailing argument now and default it to
+  the equilibrium's own `default_constraints()`. For the eight modules whose default is no longer
+  ``(g^3, g^1)`` those calls therefore return the multipliers of a different pair than before. Pass
+  `constraint_pair(:g31)` explicitly to get the old quantity.
 - **Every problem constructor is renamed to the `GeometricProblems` scheme.** No deprecation shims.
 
   | Module | Was | Is |
@@ -191,6 +197,29 @@ deprecation shims; see *Changed* below for the mapping.
 
 ### Fixed
 
+- **``\partial\lambda_{2}/\partial q`` and ``\partial\lambda_{2}/\partial p`` of the 3D guiding centre
+  carried the wrong sign** on the term proportional to ``\partial \{ g_{1}, g_{2} \} / \partial\cdot``.
+  Both multipliers are a bracket over ``\lambda_{\mathrm{o}} = \{ g_{1}, g_{2} \}``, so both derivatives
+  carry ``-\lambda \, \partial\lambda_{\mathrm{o}} / \lambda_{\mathrm{o}}`` whatever the sign of the
+  numerator; ``\lambda_{1}`` had it, ``\lambda_{2}`` had the ``+`` the quotient rule gives before the
+  minus of ``-\{ g_{1}, H \}`` is folded back in. The error was off by exactly
+  ``2 \lambda_{2} \, \partial\lambda_{\mathrm{o}} / \lambda_{\mathrm{o}}``.
+
+  Only `hodeproblem_canonical` uses these, and only multiplied by a constraint, so it vanished on the
+  constraint manifold — which is why the canonicalised form still agreed with `hodeproblem` to 1E-8 and
+  why nothing caught it. What it cost was accuracy and solver work. `TokamakMediumCartesian` now
+  conserves energy to 2.2E-9 over a hundred steps where it managed 7.7E-9 before, and `Dipole3d` — the
+  one equilibrium whose canonicalised solve needs more than one Newton iteration per stage — drops from
+  3.8 iterations per stage to 2.6, peak 50 to 9, and from 29.6× to 18.8× the cost of the Hamilton-Dirac
+  form. The right-hand side itself costs the same either way; the whole difference is the solve. The
+  cost table in [Findings](docs/src/findings.md) is updated accordingly.
+
+  It does *not* account for the canonicalised form's other weaknesses — `SolovevSymmetricField` still
+  cannot complete an orbit under it, and `Dipole3d`'s conservation is unchanged — so the comparisons
+  between the three formulations stand as written.
+
+  Now pinned by a finite-difference test on all four multiplier derivatives in three charts, at a point
+  displaced off the constraint manifold, since on it either sign passes.
 - **`sodeproblem` of the noncanonical charged particle accepted `parameters` and dropped it.**
   Neither `SODEProblem` branch forwarded the keyword, so it — and anything the named-tuple form put
   into `ics.params` — was silently discarded, unlike in `odeproblem` beside it and in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ deprecation shims; see *Changed* below for the mapping.
 
 ### Added
 
+- **All three constraint pairs of the 3D guiding centre model, and a `constraints` keyword to
+  select between them.** Only ``(g^3, g^1)`` was implemented, taken from an earlier version of Li,
+  Zhang & Liu; its Lagrange multipliers divide by `b₁`, which vanishes on the midplane of an
+  axisymmetric equilibrium — where seven of the eleven equilibria that ship an initial condition sit.
+  `hodeproblem` and `hodeproblem_canonical` now take `constraints = :g31 | :g12 | :g23`, and every
+  equilibrium declares a `default_constraints` that is regular at its own initial conditions.
+  `SolovevSymmetricField` needed all three to exist: `b = e₂` there, so two of the pairs are singular
+  at once.
+
+  Five of the seven commented-out test blocks in `test/guiding_center_3d_tests.jl` are re-enabled as
+  a result, and neither `scripts/guiding_center_3d.jl` nor `docs/src/examples/iter_cylindrical.md` has
+  to displace its initial condition off the midplane by `sqrt(eps())` any longer. The 3D guiding
+  centre test file goes from four integration blocks to ten, and correspondingly from about four
+  minutes to about ten in CI — the cost of covering nine equilibria instead of four, most of it
+  compilation of one right-hand side specialisation per (equilibrium, formulation, pair).
+
+  The constraints and all of their first and second derivatives are now written once against a
+  generic index pair in the new `src/guiding_center_3d/guiding_center_3d_constraints.jl`, rather than
+  by hand per pair, which shrank `guiding_center_3d_canonical.jl` from 722 lines to 361 rather than
+  tripling it.
+- **`hodeproblem_compact`, the compact form of the 3D guiding centre equations** — Eq. (29) of Li,
+  Zhang & Liu, which drops the constraint-proportional terms from the Hamilton-Dirac right-hand side.
+  That equation as printed is cartesian and assumes `H = ½Σ(pᵢ-Aᵢ)²`, so it is derived
+  coordinate-generally here instead of ported; the derivation is at the top of
+  `guiding_center_3d_compact.jl` and written up in `docs/src/guiding_center_3d.md`, and is checked
+  against the paper's expressions on the three cartesian equilibria in `test/structure_tests.jl`.
+
+  In that form it is *independent of the constraint pair* and free of every `bₘ` denominator, which
+  is what `constraints = :parallel`, its default, selects. Passing a pair symbol instead reproduces
+  the paper literally, `(pₘ-Aₘ)/bₘ` and its singularity included.
 - **Seven more equilibria for `GyroKinetics4d`**, which previously shipped only the ITER-like
   Solov'ev equilibrium with X-point: `SolovevIter`, `TokamakIterCylindrical`,
   `TokamakMedium{Cartesian,Cylindrical}`, `TokamakSmall{Cartesian,Cylindrical,Toroidal}`. Each
@@ -39,11 +69,11 @@ deprecation shims; see *Changed* below for the mapping.
   `initial_conditions_*` returns directly: `odeproblem(initial_conditions_deeply_passing())`, with
   that condition's own `μ` travelling in `params`.
 - **Test blocks for `Dipole3d` and `QuadraticPotentials3d`** in the 3D guiding centre suite. Neither
-  is blocked by the `b₁ = 0` singularity — `b₁` is -0.41 and 2E-3 at their initial conditions — and
-  neither had a test block at all, so the 3D model's dynamics now runs on four equilibria of eleven
-  rather than two. `QuadraticPotentials3d` is the only shipped equilibrium with a non-zero
-  potential, so it is also the only integration test that exercises the `φ` and `E` terms on a field
-  where they do not vanish.
+  was blocked by the `b₁ = 0` singularity — `b₁` is -0.41 and 2E-3 at their initial conditions — and
+  neither had a test block at all, so these took the 3D model's dynamics from two equilibria of eleven
+  to four, before the selectable constraint pair took it to nine. `QuadraticPotentials3d` is the only
+  shipped equilibrium with a non-zero potential, so it is also the only integration test that
+  exercises the `φ` and `E` terms on a field where they do not vanish.
 - **An integration test for the κ-dependent "dg" formulation** (`iodeproblem_dg`) at κ = 0, ½ and 1.
   Its `ḡ` was checked against finite differences but it had never been integrated, and κ = 0 — the
   default — reduces it to the plain `iodeproblem`, so the κ terms were entirely unexercised.
@@ -85,6 +115,15 @@ deprecation shims; see *Changed* below for the mapping.
 
 ### Changed
 
+- **The 3D guiding centre right-hand side is 2.7× faster**, incidentally to the constraint rewrite:
+  the old code evaluated `λ₁` and `λ₂` once per component of `v` and of `f`, so the two multipliers
+  and the six Poisson-bracket terms behind them were computed three times per call. A hundred steps of
+  `Dipole3d` with `PartitionedGauss(2)` went from 1383 ms to 517 ms, and `hodeproblem_canonical` from
+  11.9 s to 10.1 s. Allocations and compile time are unchanged to the byte and the second.
+- **`compute_constraints` returns three series where it returned two**, and `g₁`, `g₂` in the
+  equilibrium modules now mean the paper's ``g^1``, ``g^2`` rather than the two members of the one
+  hard-coded pair, which were ``g^3`` and ``g^1``. Anything that read `c.g₁`/`c.g₂` still reads a
+  constraint that vanishes along the flow, but not the same one.
 - **Every problem constructor is renamed to the `GeometricProblems` scheme.** No deprecation shims.
 
   | Module | Was | Is |
@@ -285,9 +324,13 @@ deprecation shims; see *Changed* below for the mapping.
 - **Diagnostics for the 3D guiding centre model.** `guiding_center_3d_diagnostics.jl` was an empty
   file, included by all thirteen equilibria, so the model had no `compute_energy`,
   `compute_energy_error` or `compute_toroidal_momentum` at all. Alongside them,
-  `compute_constraints` returns the two constraints ``g₁`` and ``g₂`` as data series: they vanish
-  along the exact flow, so their magnitude is the drift off the manifold on which `p = ϑ`, which is
-  the quantity the approximately symplectic methods are designed to keep bounded.
+  `compute_constraints` returns all three constraints ``g^1``, ``g^2``, ``g^3`` as data series: they
+  vanish along the exact flow, so their magnitude is the drift off the manifold on which `p = ϑ`,
+  which is the quantity the approximately symplectic methods are designed to keep bounded. All three
+  are reported rather than the two the problem's constraint pair retains, because the omitted one
+  carries the drift of the retained pair amplified by ``1/b_m`` — a factor of 800 over a thousand
+  steps on `TokamakMediumCartesian` — and is invisible otherwise. `SolovevIter`, whose
+  `include` of the diagnostics was commented out, has them too now.
 - **A documentation page for `GyroKinetics4d`** (`docs/src/gyro_kinetics_4d.md`), which had none
   and was not listed in the index. It derives the gyrokinetic characteristics, the rescaled time
   and the ``\beta``/``\gamma`` potentials from the notes the module follows, explains the six-way

--- a/TODO.md
+++ b/TODO.md
@@ -93,33 +93,43 @@ under a different justification.
 
 # Physics
 
-## Add the remaining constraint formulations to the 3D guiding centre model
+## ~~Add the remaining constraint formulations to the 3D guiding centre model~~ — done
 
-**Context from the author:** several formulations of the constraints exist. What is implemented is
-one variant taken from an *earlier version* of Li, Zhang & Liu — so this is incompleteness, not a
-mistake. The task is to generalise and add the missing variants.
+All three constraint pairs are implemented, selected by a `constraints = :g31` / `:g12` / `:g23`
+keyword on `hodeproblem` and `hodeproblem_canonical`, with a per-equilibrium `default_constraints`
+that is regular at that equilibrium's own initial conditions. The constraints and every one of their
+first and second derivatives are now written once against a generic index pair in
+`src/guiding_center_3d/guiding_center_3d_constraints.jl`, as decided;
+`guiding_center_3d_canonical.jl` lost some four hundred lines rather than tripling in size.
 
-This also happens to be the fix for the sharpest limitation in the package. The active pair is
-``(g^3, g^1)``, which puts ``b_1`` in the denominator of both Lagrange multipliers, and **seven of
-the eleven equilibria have ``b_1 = 0`` exactly at their shipped initial condition** — the
-multipliers are infinite and `hode` cannot be started at all. See the table in
-[findings.md](docs/src/findings.md); the pair ``(g^1, g^2)`` puts ``b_3 = b_\varphi`` there
-instead, which does not vanish on the midplane.
+The compact form of Eq. (29) is implemented as well, as a third formulation, `hodeproblem_compact`.
+Since that equation as printed is cartesian, it is derived coordinate-generally instead of ported;
+the derivation is at the top of `guiding_center_3d_compact.jl` and written up in
+[docs/src/guiding_center_3d.md](docs/src/guiding_center_3d.md). It turns out to be independent of the
+constraint pair and free of every `bₘ` denominator.
 
-Proposed shape: a `constraints = :g31` / `:g12` / `:g23` keyword threaded through `hode` and
-`hode_canonical`, defaulting to the present `:g31` for compatibility, with a per-equilibrium default
-chosen so each ships with a pair that is non-singular at its own initial condition.
+Five of the seven commented-out 3D test blocks are re-enabled. The two that are not —
+`SymmetricField` and `ThetaPinchField` — never had integration content: they called
+`guiding_center_3d_loop_ode` and `guiding_center_3d_surface_ode`, which this package no longer
+defines. See the note where those blocks used to be.
 
-The obstacle is that the constraints and *all* their first and second derivatives are written out
-by hand for one pair — `guiding_center_3d_canonical.jl` is 700 lines of it.
+Two things this left open, neither of them about the constraint pair:
 
-**Decided: restructure around `Val{:g31}`-style dispatch** rather than hand-writing the other two
-pairs or generating the derivatives symbolically. Writing the constraints and their derivatives
-once against a generic index pair shrinks that file instead of tripling it, at the cost of touching
-every line of it. Do not open this again as a three-way choice.
-
-Once it works, re-enable the commented-out 3D test blocks in `test/guiding_center_3d_tests.jl`
-(~150 lines, all of them blocked on exactly this).
+* **`hodeproblem_canonical` diverges on `SolovevSymmetricField`** after some thirty steps, although
+  the pair is well conditioned there (``\lambda_o \approx -228``) and the same orbit runs to
+  completion under `hodeproblem` and `hodeproblem_compact`. The ``\partial\lambda/\partial q``,
+  ``\partial\lambda/\partial p`` terms amplify the constraint drift rather than ignoring it. It is
+  the only equilibrium where this happens.
+* **The omitted constraint drifts `1/bₘ` times as much as the retained pair**, since
+  ``b_1 g^2 - b_2 g^1 + b_3 g^3 = 0`` determines it from them. On the ITER Solov'ev X-point that is a
+  factor of 170. Nothing is wrong with it, but it is one of two reasons to prefer the pair whose
+  ``b_m`` is largest rather than merely non-zero.
+* **`default_constraints` is chosen on regularity at the initial condition, not on conditioning along
+  the orbit** — with one exception. `Dipole3d` had to be moved to `:g12` because its orbit takes both
+  `b₁` and `b₂` through zero and the other two pairs lose the orbit entirely by ``t = 30``. The rest
+  were left where regularity put them, including `TokamakMediumCartesian` at ``\lambda_o = -0.15``
+  where `:g23` would give ``-3.8``, because changing them moves numbers that findings.md tabulates.
+  A sweep of ``\min |b_m|`` along each shipped orbit would settle all eleven properly.
 
 ## One initial-conditions layer for all models
 
@@ -246,10 +256,6 @@ observed order of a few would be cheap and would validate the subsystem integrat
 
 # Smaller things
 
-* `test/guiding_center_3d_tests.jl` has ~150 lines of commented-out test blocks. Every equilibrium
-  they cover — `TokamakMediumCylindrical`, `TokamakSmall{Cartesian,Cylindrical,Toroidal}`,
-  `SolovevSymmetricField` — has `b₁ = 0` at its initial condition, so all are blocked on the
-  constraint-formulation item above.
 * Per-equilibrium docstrings: the coordinate system and the equilibrium parameters are now stated
   everywhere. The provenance of the hard-coded `μ` and `u` is not, because it is unknown — see
   *One initial-conditions layer for all models* above, which subsumes this. If the derivation
@@ -273,11 +279,11 @@ observed order of a few would be cheap and would validate the subsystem integrat
 Observations from reviewing the audit that were not defects and so were not fixed with it. Recorded
 here rather than lost in a pull request thread.
 
-* **Integration coverage of `GuidingCenter3d` is four equilibria of eleven** — `SolovevIterXpoint`,
-  `TokamakMediumCartesian`, and now `Dipole3d` and `QuadraticPotentials3d`. The structure tests
-  cover all eleven but do not integrate. The remaining seven are blocked by the `b₁ = 0`
-  singularity rather than by anything the audit did; fixing the constraint pair fixes the coverage
-  too, and until then it is worth knowing how thin it is.
+* **Integration coverage of `GuidingCenter3d` was four equilibria of eleven** — the remaining seven
+  were blocked by the `b₁ = 0` singularity of the one implemented constraint pair rather than by
+  anything the audit did. Selecting the pair per equilibrium lifted that: nine of the eleven now
+  integrate, and the two that do not (`SymmetricField`, `ThetaPinchField`) ship Poincaré-invariant
+  loops rather than initial conditions and never had integration tests to begin with.
 * **The SciML reformat landed in the same commits as the semantic changes**, which makes several
   equilibrium modules read as whole-file rewrites; `git diff -w` is the way to review them. Worth
   keeping formatting sweeps to their own commit next time, now that `.JuliaFormatter.toml` exists
@@ -290,9 +296,10 @@ here rather than lost in a pull request thread.
 
 Recorded so a future session does not re-open them.
 
-**Constraint pair.** Not a mistake — the implemented variant comes from an earlier version of the
-paper, and the others are simply missing. Generalising is a planned task; see above. The shape is
-settled too: `Val{:g31}`-style dispatch, not hand-written pairs or symbolic generation.
+**Constraint pair.** Not a mistake — the implemented variant came from an earlier version of the
+paper, and the others were simply missing. All three now exist, on `Val{:g31}`-style dispatch as
+settled, along with the compact form of Eq. (29); see above. There is nothing left to decide here
+except which pair each equilibrium should *prefer* among those that are regular for it.
 
 **The suppressed-warning count is not a tripwire.** It is reported by `@info` and nothing asserts
 on it. A threshold was considered and rejected: which orbits exhaust the solver's iteration budget

--- a/docs/src/audit.md
+++ b/docs/src/audit.md
@@ -121,10 +121,12 @@ g^{3} &= b_{1} v_{2} - b_{2} v_{1} ,
 ```
 
 and shows (§4.1–4.2) that the Lagrange multipliers carry
-``\{ g_{1}, g_{2} \} = b_{m} [ B + (p - A) \cdot (\nabla \times b) ]`` in their denominator, with
-``m`` the index of the constraint the pair leaves out: ``b_{3}`` for ``(g^{1}, g^{2})``, ``b_{1}``
-for ``(g^{3}, g^{1})``, ``b_{2}`` for ``(g^{2}, g^{3})``. Each pair is therefore singular on a
-different surface.
+``\{ g_{1}, g_{2} \} = \pm b_{m} [ B + (p - A) \cdot (\nabla \times b) ]`` in their denominator, with
+``m`` the index of the constraint the pair leaves out: ``+b_{3}`` for ``(g^{1}, g^{2})``, ``+b_{1}``
+for ``(g^{3}, g^{1})``, ``-b_{2}`` for ``(g^{2}, g^{3})``. Each pair is therefore singular on a
+different surface. The sign is a consequence of how each pair is ordered rather than of anything
+physical — see `constraint_pair` — but it is spelled out because it means ``\lambda_{\mathrm{o}}`` and
+``b_{m}`` need not share a sign in the tabulated values.
 
 The implementation once used ``(g^{3}, g^{1})`` alone, and **seven of the eleven equilibria have
 ``b_{1} = 0`` exactly at the initial condition the package ships**, so the multipliers were infinite

--- a/docs/src/audit.md
+++ b/docs/src/audit.md
@@ -121,30 +121,41 @@ g^{3} &= b_{1} v_{2} - b_{2} v_{1} ,
 ```
 
 and shows (§4.1–4.2) that the Lagrange multipliers carry
-``\{ g^{1}, g^{2} \} = b_{3} [ B + (p - A) \cdot (\nabla \times b) ]`` in their denominator for the
-pair ``(g^{1}, g^{2})``, and ``b_{1} [ \cdots ]`` for the pair ``(g^{1}, g^{3})``.
+``\{ g_{1}, g_{2} \} = b_{m} [ B + (p - A) \cdot (\nabla \times b) ]`` in their denominator, with
+``m`` the index of the constraint the pair leaves out: ``b_{3}`` for ``(g^{1}, g^{2})``, ``b_{1}``
+for ``(g^{3}, g^{1})``, ``b_{2}`` for ``(g^{2}, g^{3})``. Each pair is therefore singular on a
+different surface.
 
-**This implementation uses the pair ``(g^{3}, g^{1})``**, so the multipliers are singular wherever
-``b_{1} = 0``.
-
-**Seven of the eleven equilibria have ``b_{1} = 0`` exactly at the initial condition the package
-ships**, so the multipliers are infinite and `hodeproblem` cannot be started there at all — the Newton
-solver hits a NaN on the first step. This is not confined to the curvilinear cases:
-`TokamakSmallCartesian` fails too, because its initial condition sits at ``y = z = 0`` where
+The implementation once used ``(g^{3}, g^{1})`` alone, and **seven of the eleven equilibria have
+``b_{1} = 0`` exactly at the initial condition the package ships**, so the multipliers were infinite
+and `hodeproblem` could not be started there at all. This was not confined to the curvilinear cases:
+`TokamakSmallCartesian` failed too, because its initial condition sits at ``y = z = 0`` where
 ``B_{x} = 0``. What decides it is where the initial condition lies relative to the field, not the
 coordinate system.
 
-The four that do work — `Dipole3d`, `QuadraticPotentials3d`, `TokamakMediumCartesian` and
-`SolovevIterXpoint` — are exactly the ones the test suite and the scripts exercise. The remaining
-3D test blocks are commented out for this reason, and `scripts/guiding_center_3d.jl` displaces its
-initial condition off the midplane by `sqrt(eps())` to work around it. Even `SolovevIterXpoint` is
-only marginal, at ``b_{1} \approx 5.9 \times 10^{-3}``.
+**All three pairs are now implemented and selectable** through the `constraints` keyword, and each
+equilibrium declares a `default_constraints` that is regular at its own initial conditions. Nine of
+the eleven equilibria integrate as a result, and the two that do not — `SymmetricField` and
+`ThetaPinchField` — ship Poincaré-invariant loops rather than point initial conditions and never had
+integration tests. `SolovevSymmetricField` is the case that made all three necessary rather than two:
+``b = e_{2}`` there, so ``b_{1}`` and ``b_{3}`` vanish together and only ``(g^{2}, g^{3})`` survives.
 
-Choosing ``(g^{1}, g^{2})`` instead puts ``b_{3} = b_{\varphi}`` in the denominator — the largest
-component of a tokamak field, and non-zero on the midplane — which would make most of these
-equilibria usable. The choice is hard-coded, with the alternative commented out beside it in
-`guiding_center_3d_equations.jl`. See [Findings](@ref) for the measurements and `TODO.md` for the
-proposed fix.
+Two residual limitations are worth knowing about, neither of them removable by choosing a pair.
+
+* **A pair that is regular at the initial condition can still be badly conditioned along the orbit.**
+  `Dipole3d` is regular for all three, but its orbit takes ``b_{1}`` and ``b_{2}`` through zero, and
+  the two pairs that divide by them lose the orbit entirely past ``t = 30``. Its default is chosen on
+  the conditioning along the orbit for that reason; the other ten are chosen on regularity at the
+  initial condition alone. See `TODO.md`.
+* **The omitted constraint is conserved ``1/b_{m}`` times worse than the retained pair**, since
+  ``b_{1} g^{2} - b_{2} g^{1} + b_{3} g^{3} = 0`` determines it from them pointwise. This is why
+  `compute_constraints` reports all three components rather than the two the pair retains.
+
+The compact form of the paper's Eq. (29), `hodeproblem_compact`, is free of the ``b_{m}``
+denominator altogether and does not depend on the pair; see
+[Guiding Center Dynamics in 3D](@ref) for the derivation, which had to be redone
+coordinate-generally because Eq. (29) as printed is cartesian. See [Findings](@ref) for the
+measurements.
 
 ### The two-form of the 4D guiding centre
 
@@ -226,9 +237,9 @@ and additionally accept the named tuple that every `initial_conditions_*` return
 
 ## Open work
 
-* Make the 3D guiding centre constraint pair selectable. This is the sharpest remaining limitation:
-  seven of the eleven equilibria have ``b_{1} = 0`` at their shipped initial condition and cannot be
-  started at all.
+* Choose each 3D guiding centre equilibrium's `default_constraints` on the conditioning of the pair
+  along its orbit rather than on regularity at the initial condition. Only `Dipole3d`, where the
+  difference is four orders of magnitude, is currently chosen that way.
 * Write the coordinate-transforming `IRK` integrator that `coordinate_transformations.jl` is waiting
   for. The 0.x-era sketch is on file at
   `src/gyro_kinetics_4d/irk_with_coordinate_transformation.jl` as the starting point; it is not

--- a/docs/src/examples/iter_cylindrical.md
+++ b/docs/src/examples/iter_cylindrical.md
@@ -59,11 +59,12 @@ Obtain guiding center initial conditions:
 q₀, μ = guiding_center(ics)
 ```
 
-Modify guiding center initial conditions for 3D models to avoid singularities:
+The 3D model can use the guiding centre initial condition as it stands. It used to need displacing
+off the midplane by `sqrt(eps())`, because the only constraint pair it implemented divides by
+`b₁ = b_R`, which vanishes there; `TokamakIterCylindrical` now defaults to the pair that divides by
+`b₃ = b_φ` instead.
 ```@example 1
-q3₀ = copy(q₀)
-q3₀[2] = sqrt(eps())
-q3₀
+q3₀ = q₀
 ```
 
 Parameters:

--- a/docs/src/findings.md
+++ b/docs/src/findings.md
@@ -15,7 +15,7 @@ All numbers below were produced on the state of the branch at the time of writin
 reproducible but not pinned by a test, so treat small differences as normal.
 
 
-## Conditioning of the 3D guiding centre constraint pair
+## Conditioning of the 3D guiding centre constraint formulations
 
 `scripts/study_guiding_center_3d_conditioning.jl`
 
@@ -26,45 +26,136 @@ by two of the three independent components of `v × b = 0`,
 g¹ = b₁ v₃ - b₃ v₁ ,    g² = b₂ v₃ - b₃ v₂ ,    g³ = b₁ v₂ - b₂ v₁ ,
 ```
 
-and the Poisson bracket in the denominator of both Lagrange multipliers is
-`b₃ [B + (p-A)·(∇×b)]` for the pair `(g¹, g²)` and `b₁ [ … ]` for `(g¹, g³)`. This package uses
-`(g³, g¹)`, so it is singular wherever `b₁ = 0`.
+and the Poisson bracket in the denominator of both Lagrange multipliers carries a factor of the
+`b`-component belonging to the constraint the pair leaves out: `b₁` for `(g³, g¹)` (`constraints =
+:g31`), `b₃` for `(g¹, g²)` (`:g12`), `b₂` for `(g², g³)` (`:g23`). The package once implemented
+`(g³, g¹)` alone, so it was singular wherever `b₁ = 0`.
 
-At the shipped initial condition of each equilibrium:
 
-| equilibrium | coords | b₁ | λₒ | λ₁ | λ₂ |
-|---|---|---|---|---|---|
-| Dipole3d                 | cartesian   | -4.082e-01 | -3.402e+01 | 7.779e-03 | 5.874e-15 |
-| QuadraticPotentials3d    | cartesian   | 2.000e-03  | 2.000e-01  | 1.514e+00 | 6.500e-03 |
-| TokamakSmallCartesian    | cartesian   | -0.000e+00 | 0.000e+00  | **-Inf**  | **Inf**   |
-| TokamakMediumCartesian   | cartesian   | -3.966e-02 | -1.537e-01 | 5.232e-02 | -4.172e-01 |
-| TokamakSmallCylindrical  | cylindrical | 0.000e+00  | 0.000e+00  | **Inf**   | **-Inf**  |
-| TokamakMediumCylindrical | cylindrical | 0.000e+00  | 0.000e+00  | **Inf**   | **-Inf**  |
-| TokamakIterCylindrical   | cylindrical | 0.000e+00  | 0.000e+00  | **Inf**   | **Inf**   |
-| SolovevIter              | cylindrical | 0.000e+00  | 0.000e+00  | **Inf**   | **Inf**   |
-| SolovevIterXpoint        | cylindrical | 5.926e-03  | 1.207e+00  | 7.113e-01 | 7.470e-03 |
-| SolovevSymmetricField    | cylindrical | -0.000e+00 | 0.000e+00  | **NaN**   | **-Inf**  |
-| TokamakSmallToroidal     | toroidal    | 0.000e+00  | 0.000e+00  | **Inf**   | **-Inf**  |
+### Which pairs are usable
+
+At the shipped initial condition of each equilibrium. `λₒ = {g₁, g₂}` is the bracket both
+multipliers divide by; `D` is the same quantity as the compact form computes it, as a weighted mean
+over all three pairs that never divides by a single component of `b`.
+
+| equilibrium | coords | b₁ | b₂ | b₃ | λₒ(:g31) | λₒ(:g12) | λₒ(:g23) | D | default |
+|---|---|---|---|---|---|---|---|---|---|
+| Dipole3d                 | cartesian   | -4.082e-01 | -8.165e-01 | 4.082e-01  | -3.402e+01 | 3.402e+01  | 6.804e+01  | 8.333e+01 | `:g12` |
+| QuadraticPotentials3d    | cartesian   | 2.000e-03  | -3.000e-03 | 1.000e+00  | 2.000e-01  | 9.999e+01  | 3.000e-01  | 9.999e+01 | `:g31` |
+| TokamakSmallCartesian    | cartesian   | **0**      | 9.997e-01  | 2.499e-02  | **0**      | 2.379e-02  | -9.516e-01 | 9.519e-01 | `:g23` |
+| TokamakMediumCartesian   | cartesian   | -3.966e-02 | 9.914e-01  | 1.245e-01  | -1.537e-01 | 4.827e-01  | -3.843e+00 | 3.876e+00 | `:g31` |
+| TokamakSmallCylindrical  | cylindrical | **0**      | -2.499e-02 | -1.050e+00 | **0**      | -1.051e+00 | 2.502e-02  | 1.001e+00 | `:g12` |
+| TokamakMediumCylindrical | cylindrical | **0**      | -1.245e-01 | -2.483e+00 | **0**      | -2.596e+01 | 1.302e+00  | 1.046e+01 | `:g12` |
+| TokamakIterCylindrical   | cylindrical | **0**      | 3.888e-01  | -2.303e+00 | **0**      | -8.281e+01 | -1.398e+01 | 3.595e+01 | `:g12` |
+| SolovevIter              | cylindrical | **0**      | 2.387e-02  | -2.500e+00 | **0**      | -5.093e+02 | -4.862e+00 | 2.037e+02 | `:g12` |
+| SolovevIterXpoint        | cylindrical | 5.926e-03  | 2.626e-02  | -2.500e+00 | 1.207e+00  | -5.093e+02 | -5.349e+00 | 2.037e+02 | `:g31` |
+| SolovevSymmetricField    | cylindrical | **0**      | 1.000e+00  | **0**      | **0**      | **0**      | -2.278e+02 | 2.278e+02 | `:g23` |
+| TokamakSmallToroidal     | toroidal    | **0**      | -1.498e-03 | -1.054e+00 | **0**      | -5.780e-02 | 8.213e-05  | 5.482e-02 | `:g12` |
 
 **Seven of eleven equilibria have `b₁ = 0` exactly at the initial condition the package ships**, so
-`λₒ` vanishes and the multipliers are infinite. `hodeproblem` cannot be started there at all — the Newton
-solver hits a NaN in the direction vector on the first step.
+`λₒ` vanishes for `(g³, g¹)` and its multipliers are infinite. Those problems cannot be started at
+all — the Newton solver hits a NaN in its direction vector on the first step — which is why the
+package used to integrate on four equilibria of eleven. `SolovevSymmetricField` is the case that
+made all three pairs necessary rather than two: `b = e₂` there, so `b₁` and `b₃` vanish together and
+only `(g², g³)` survives.
 
 Two things about this are worth recording:
 
-* **It is not a curvilinear-coordinates problem.** `TokamakSmallCartesian` fails too: its initial
-  condition sits at `y = z = 0`, where `B_x = 0`. What decides the outcome is where the initial
-  condition lies relative to the field, not the coordinate system. The four survivors are simply
-  the ones whose initial condition is off the symmetry plane.
-* **The survivors are exactly the equilibria the test suite exercises**, plus the two toy problems
-  that have their own scripts. That is not a coincidence — the other 3D test blocks were commented
-  out, and `scripts/guiding_center_3d.jl` displaces its initial condition off the midplane by
-  `sqrt(eps())`, both of which are workarounds for this.
+* **It is not a curvilinear-coordinates problem.** `TokamakSmallCartesian` fails for `(g³, g¹)` too:
+  its initial condition sits at `y = z = 0`, where `B_x = 0`. What decides the outcome is where the
+  initial condition lies relative to the field, not the coordinate system.
+* **`D` is finite everywhere**, including where two of the three pairs are singular. The three
+  ratios `{cᵢ,cⱼ}(m) / bₘ` it averages agree to machine precision wherever they are all defined, in
+  every chart — which is what makes the average a faithful stand-in for the singular ratio rather
+  than a fudge, and is the numerical check on the derivation in
+  `src/guiding_center_3d/guiding_center_3d_compact.jl`.
 
-Switching to `(g¹, g²)` puts `b₃ = b_φ` in the denominator — the largest component of a tokamak
-field, and non-zero on the midplane — which would make most of these equilibria usable. The choice
-is hard-coded in `guiding_center_3d_equations.jl`, with the alternative commented out beside it.
-See `TODO.md` in the repository root.
+
+### The formulations agree where they are all usable
+
+A hundred steps at min(`DEFAULT_TIMESTEP`, 0.1) with `PartitionedGauss(2)`. `Δy` is the relative
+deviation of the final `(q, p)` from the compact form in its `:parallel` variant, which is used as
+the reference because it is the only one of the six defined for every equilibrium.
+
+| equilibrium | variant | Δy | \|ΔH/H\| | max\|gᵏ\| |
+|---|---|---|---|---|
+| TokamakMediumCartesian | hode `:g31`         | 2.243e-10 | 6.016e-11 | 8.239e-10 |
+|                        | hode `:g12`         | 1.930e-09 | 6.028e-11 | 9.677e-09 |
+|                        | hode `:g23`         | 5.666e-09 | 6.018e-11 | 2.638e-08 |
+|                        | canonical `:g31`    | 7.480e-09 | 7.658e-09 | 1.329e-08 |
+|                        | compact `:g31`      | 3.414e-11 | 5.807e-11 | 1.321e-10 |
+|                        | compact `:parallel` | —         | 5.745e-11 | 1.345e-10 |
+
+`TokamakMediumCartesian` is the only equilibrium for which no component of `b` vanishes at the
+initial condition, so it is the only one where all three pairs can be compared directly. They agree
+to 6e-9 — the accuracy of the nonlinear solve at this tolerance — which is the substantive check
+that the three pairs parameterise the same constrained system and that the compact form is equivalent
+to the Hamilton-Dirac one it was derived from. The same holds on every other equilibrium for the
+pairs that are regular there; the full table is in the script's output.
+
+Two entries in that table are not agreements. `Dipole3d` disagrees by 2e-4 between its
+well-conditioned pair and its two badly conditioned ones, which is the subject of the next section.
+And `SolovevSymmetricField` cannot run `hodeproblem_canonical` at all: its pair is well conditioned,
+`λₒ ≈ -228` and never below -173 along the orbit, but the `∂λ/∂q`, `∂λ/∂p` terms the canonicalised
+form adds amplify the constraint drift enough that Newton meets a NaN after some thirty steps. The
+same orbit runs to completion under `hodeproblem` and `hodeproblem_compact`. It is the only
+equilibrium where this happens, and it is a property of that formulation rather than of the
+constraint pair.
+
+
+### Regular is not the same as well conditioned
+
+`Dipole3d` is where that distinction bites. All three pairs are regular at its initial condition —
+`λₒ` is -34, 34 and 68 — but the orbit takes `b₁` and `b₂` through zero:
+
+| variant | max\|gᵏ\| at t = 3 | \|ΔH/H\| at t = 3 | \|ΔH/H\| at t = 30 |
+|---|---|---|---|
+| hode `:g31` | 1.30e-03 | 4.06e-05 | 2e+03 |
+| hode `:g23` | 1.69e-03 | 3.98e-05 | not measured |
+| hode `:g12` | 1.83e-08 | 1.98e-09 | 1.98e-09 |
+| canonical `:g31` | 3.27e-05 | 8.11e-07 | NaN in the Newton direction |
+| canonical `:g12` | 5.62e-06 | 1.57e-08 | 1.57e-08 |
+
+Four orders of magnitude at `t = 3`, and past `t = 30` the badly conditioned pair loses the orbit
+altogether — `|ΔH/H| = 2e+03` is not an error estimate, it is a destroyed trajectory. With `:g12`
+both the Hamilton-Dirac and the canonicalised form hold their levels out to `t = 300`.
+
+`Dipole3d` is therefore the one equilibrium whose `default_constraints` is chosen on the conditioning
+of the pair *along the orbit* rather than at the initial condition. The others were left where
+regularity put them; see `TODO.md`.
+
+The related effect is that the constraint the pair omits is conserved `1/bₘ` times worse than the two
+it retains, since `b₁g² - b₂g¹ + b₃g³ = 0` determines it from them pointwise. Over a thousand steps
+of `TokamakMediumCartesian` with `:g31` the retained pair holds to 2e-9 while the omitted `g²`
+reaches 1.4e-6, the orbit having passed through `b₁ = 3.5e-4`. That is why `compute_constraints`
+reports all three.
+
+
+### What the formulations cost
+
+Per step, taking the Hamilton-Dirac form as unity. Measured across all eleven equilibria; the spread
+between them is a few percent.
+
+| formulation | relative cost | why |
+|---|---|---|
+| compact, literal pair | 0.86 – 0.95 | replaces both multipliers by a single bracket ratio; no second derivatives |
+| Hamilton-Dirac | 1 | two multipliers over six bracket terms |
+| compact, `:parallel` | 1.21 – 1.44 | the regularised `D` averages all three brackets, so nine terms rather than three |
+| canonicalised | 8.9 – 29.6 | `∂λ/∂q` and `∂λ/∂p` need every second derivative of the field |
+
+The three pairs cost the same as each other to within noise — they are the same expressions with
+permuted indices — so the pair should be chosen on conditioning alone. The order of magnitude on the
+canonicalised form is the number worth remembering: it buys exact symplecticity rather than
+approximate, and gives up two to three orders of magnitude of energy and constraint conservation for
+it at these step sizes. Its spread is wider than the others because part of the cost is the harder
+nonlinear solve, not only the right-hand side: `Dipole3d`, the worst case at 29.6, is also the only
+one where Newton needs more than one iteration per stage on average.
+
+Separately, the rewrite of the constraints made the Hamilton-Dirac right-hand side **2.7× faster**:
+the old code evaluated `λ₁` and `λ₂` once per component, so the multipliers and the six bracket
+terms behind them were computed three times per call. A hundred steps of `Dipole3d` went from
+1383 ms to 517 ms, and `hodeproblem_canonical` from 11.9 s to 10.1 s, with allocations and compile
+time unchanged.
 
 
 ## The toroidal momentum of the guiding centre models
@@ -195,18 +286,30 @@ the equations of motion agree.
 | SolovevIterXpoint       | 1.39e-15 | 4.69e-13 |
 
 3D guiding centre, `HODEProblem` with PartitionedGauss(2). The informative column is not the energy
-but the two constraints: they vanish along the exact flow, so their magnitude is the drift off the
+but the constraints: they vanish along the exact flow, so their magnitude is the drift off the
 manifold on which `p = ϑ` — the quantity the approximately symplectic methods are designed to keep
-bounded, and the reason `compute_constraints` was added to the diagnostics.
+bounded, and the reason `compute_constraints` was added to the diagnostics. The constraint the pair
+omits is listed separately from the two it retains, because it is the retained pair's drift amplified
+by `1/bₘ`.
 
-| equilibrium | \|ΔH/H\| | \|g₁\| | \|g₂\| | \|Δp_φ/p_φ\| |
-|---|---|---|---|---|
-| SolovevIterXpoint      | 5.74e-15 | 1.13e-15 | 1.47e-13 | 0.00e+00 |
-| TokamakMediumCartesian | 3.23e-10 | 7.07e-10 | 1.78e-09 | — |
+| equilibrium | pair | \|ΔH/H\| | \|gᵏ\| retained | \|gᵏ\| omitted | \|Δp_φ/p_φ\| |
+|---|---|---|---|---|---|
+| SolovevIterXpoint        | `:g31` | 5.39e-15 | 1.49e-13 | 9.33e-13 | 0.00e+00 |
+| TokamakMediumCartesian   | `:g31` | 3.23e-10 | 1.78e-09 | 1.45e-06 | — |
+| TokamakSmallCylindrical  | `:g12` | 6.84e-15 | 1.31e-15 | 1.11e-18 | 0.00e+00 |
+| TokamakMediumCylindrical | `:g12` | 2.04e-13 | 7.43e-13 | 2.62e-14 | 0.00e+00 |
+| TokamakSmallToroidal     | `:g12` | 1.12e-15 | 1.22e-17 | 1.50e-20 | 0.00e+00 |
 
-Only the two equilibria that can be started at all appear; see the conditioning section above.
-`p_φ` is conserved *exactly* for the cylindrical case because φ is cyclic and the partitioned
-symplectic method conserves the conjugate momentum of a cyclic coordinate to round-off.
+The three equilibria at the bottom are ones that could not be started at all before the constraint
+pair became selectable. `SolovevSymmetricField`, which also could not, still cannot be run over a
+thousand steps: it is the stiffest equilibrium in the package at `‖ϑ‖ ≈ 256` and the drift takes
+Newton into a NaN a few hundred steps in. The `:g12` rows show the amplification working the *other*
+way — `b₃` is the large component there, so the omitted constraint comes out better conserved than
+the retained pair rather than worse. `TokamakMediumCartesian` is the case where it hurts: `b₁` falls
+to 3.5e-4 along that orbit.
+
+`p_φ` is conserved *exactly* for the cylindrical and toroidal cases because φ is cyclic and the
+partitioned symplectic method conserves the conjugate momentum of a cyclic coordinate to round-off.
 
 Gyrokinetic guiding centre, over the module's default span (~200 units of physical time):
 

--- a/docs/src/findings.md
+++ b/docs/src/findings.md
@@ -27,9 +27,13 @@ g¹ = b₁ v₃ - b₃ v₁ ,    g² = b₂ v₃ - b₃ v₂ ,    g³ = b₁ v�
 ```
 
 and the Poisson bracket in the denominator of both Lagrange multipliers carries a factor of the
-`b`-component belonging to the constraint the pair leaves out: `b₁` for `(g³, g¹)` (`constraints =
-:g31`), `b₃` for `(g¹, g²)` (`:g12`), `b₂` for `(g², g³)` (`:g23`). The package once implemented
+`b`-component belonging to the constraint the pair leaves out: `+b₁` for `(g³, g¹)` (`constraints =
+:g31`), `+b₃` for `(g¹, g²)` (`:g12`), `-b₂` for `(g², g³)` (`:g23`). The package once implemented
 `(g³, g¹)` alone, so it was singular wherever `b₁ = 0`.
+
+The minus on the third of those follows from that pair's ordering, not from the physics — reversing a
+pair flips `λₒ` and both multipliers together — so only `|λₒ|` is meaningful. It is worth noting when
+reading the table below, where `λₒ(:g23)` and `b₂` come out with opposite signs throughout.
 
 
 ### Which pairs are usable
@@ -82,7 +86,7 @@ the reference because it is the only one of the six defined for every equilibriu
 | TokamakMediumCartesian | hode `:g31`         | 2.243e-10 | 6.016e-11 | 8.239e-10 |
 |                        | hode `:g12`         | 1.930e-09 | 6.028e-11 | 9.677e-09 |
 |                        | hode `:g23`         | 5.666e-09 | 6.018e-11 | 2.638e-08 |
-|                        | canonical `:g31`    | 7.480e-09 | 7.658e-09 | 1.329e-08 |
+|                        | canonical `:g31`    | 2.248e-09 | 2.198e-09 | 1.318e-08 |
 |                        | compact `:g31`      | 3.414e-11 | 5.807e-11 | 1.321e-10 |
 |                        | compact `:parallel` | —         | 5.745e-11 | 1.345e-10 |
 
@@ -113,12 +117,13 @@ constraint pair.
 | hode `:g31` | 1.30e-03 | 4.06e-05 | 2e+03 |
 | hode `:g23` | 1.69e-03 | 3.98e-05 | not measured |
 | hode `:g12` | 1.83e-08 | 1.98e-09 | 1.98e-09 |
-| canonical `:g31` | 3.27e-05 | 8.11e-07 | NaN in the Newton direction |
-| canonical `:g12` | 5.62e-06 | 1.57e-08 | 1.57e-08 |
+| canonical `:g31` | 3.27e-05 | 8.16e-07 | 7.6e+05 |
+| canonical `:g12` | 5.63e-06 | 1.59e-08 | 1.66e-08 |
 
 Four orders of magnitude at `t = 3`, and past `t = 30` the badly conditioned pair loses the orbit
-altogether — `|ΔH/H| = 2e+03` is not an error estimate, it is a destroyed trajectory. With `:g12`
-both the Hamilton-Dirac and the canonicalised form hold their levels out to `t = 300`.
+altogether under both formulations — `|ΔH/H|` of 2e+03 and 7.6e+05 are not error estimates, they are
+destroyed trajectories. With `:g12` both the Hamilton-Dirac and the canonicalised form hold their
+levels out to `t = 300`.
 
 `Dipole3d` is therefore the one equilibrium whose `default_constraints` is chosen on the conditioning
 of the pair *along the orbit* rather than at the initial condition. The others were left where
@@ -141,15 +146,23 @@ between them is a few percent.
 | compact, literal pair | 0.86 – 0.95 | replaces both multipliers by a single bracket ratio; no second derivatives |
 | Hamilton-Dirac | 1 | two multipliers over six bracket terms |
 | compact, `:parallel` | 1.21 – 1.44 | the regularised `D` averages all three brackets, so nine terms rather than three |
-| canonicalised | 8.9 – 29.6 | `∂λ/∂q` and `∂λ/∂p` need every second derivative of the field |
+| canonicalised | 8.9 – 18.8 | `∂λ/∂q` and `∂λ/∂p` need every second derivative of the field |
 
 The three pairs cost the same as each other to within noise — they are the same expressions with
 permuted indices — so the pair should be chosen on conditioning alone. The order of magnitude on the
 canonicalised form is the number worth remembering: it buys exact symplecticity rather than
-approximate, and gives up two to three orders of magnitude of energy and constraint conservation for
-it at these step sizes. Its spread is wider than the others because part of the cost is the harder
-nonlinear solve, not only the right-hand side: `Dipole3d`, the worst case at 29.6, is also the only
-one where Newton needs more than one iteration per stage on average.
+approximate, and gives up as much as two or three orders of magnitude of energy conservation and four
+or five of constraint conservation for it at these step sizes. The spread there is wide — on five of
+the eleven equilibria it is within a factor of two of the Hamilton-Dirac form on both, and on
+`TokamakSmallCartesian` it conserves energy slightly better — so the figure to expect is the worst
+case, not the typical one.
+
+Its cost spread is wider than the other formulations' for the same reason: part of it is the harder
+nonlinear solve rather than the right-hand side. `Dipole3d`, the worst case at 18.8, is the only
+equilibrium where Newton needs more than one iteration per stage on average — 2.6, against 1.0
+everywhere else. That row read 29.6 before the sign error in `∂λ₂/∂q` and `∂λ₂/∂p` was fixed, which
+had Newton at 3.8 iterations per stage and a peak of 50; the right-hand side itself costs the same
+either way.
 
 Separately, the rewrite of the constraints made the Hamilton-Dirac right-hand side **2.7× faster**:
 the old code evaluated `λ₁` and `λ₂` once per component, so the multipliers and the six bracket

--- a/docs/src/guiding_center_3d.md
+++ b/docs/src/guiding_center_3d.md
@@ -10,8 +10,10 @@ companion Ruili Zhang, Jian Liu, Tong Liu, Wenxiang Li and Xiaogang Wang, *Canon
 guiding center theory and classical intrinsic magnetic moment*, Frontiers of Physics **21**(2),
 026200 (2026).
 
+Equation numbers below refer to the first of those two papers.
 
-## Canonical Formulation
+
+## Where the constraints come from
 
 The starting point is the guiding centre one-form ``\vartheta(r,u) = A (r) + u \, b (r)``, where ``A`` is the magnetic vector potential, ``B = \nabla \times A`` and ``b = B / \vert B \vert``.
 Identifying the momentum with the one-form,
@@ -30,47 +32,160 @@ H (r,p) = \tfrac{1}{2} \, \vert v (r,p) \vert^{2} + \mu \, \vert B (r) \vert + \
 ```
 with the magnetic moment ``\mu`` and the electrostatic potential ``\varphi``.
 
-By construction ``v`` is parallel to ``b``, which is not preserved by the unconstrained canonical flow.
-The two independent components of ``v \times b = 0`` are therefore imposed as constraints,
+The Legendre transform is degenerate: ``\partial L / \partial \dot{r} = M(r) \dot{r} + A(r)`` with ``M = b \otimes b`` of rank one, so ``p`` has only one independent component along ``b`` and the three momenta are tied together by
+```math
+\frac{p_{1} - A_{1}}{b_{1}} = \frac{p_{2} - A_{2}}{b_{2}} = \frac{p_{3} - A_{3}}{b_{3}} ,
+```
+that is by ``v \times b = 0``. Two of the three components of that are independent, and Li, Zhang and Liu label the three as (Eqs. 4 and 5)
 ```math
 \begin{aligned}
-g_{1} (r,p) &= b_{1} (r) \, v_{2} (r,p) - b_{2} (r) \, v_{1} (r,p) = 0 , \\
-g_{2} (r,p) &= b_{1} (r) \, v_{3} (r,p) - b_{3} (r) \, v_{1} (r,p) = 0 ,
+g^{1} (r,p) &= b_{1} \, v_{3} - b_{3} \, v_{1} , \\
+g^{2} (r,p) &= b_{2} \, v_{3} - b_{3} \, v_{2} , \\
+g^{3} (r,p) &= b_{1} \, v_{2} - b_{2} \, v_{1} .
 \end{aligned}
 ```
-so that the dynamics is governed by
+They are the components of ``b \times v`` up to labelling and sign, ``c_{k} = \varepsilon_{kab} \, b_{a} v_{b}``, with
+```math
+c_{1} = g^{2} , \qquad c_{2} = - g^{1} , \qquad c_{3} = g^{3} ,
+```
+which is what makes them one indexed family rather than three separate expressions. In the source they are `gᵏ(Val(k), t, q, p)`, with `constraint_indices` supplying the pair of field indices each is built from, and every first and second derivative of them is written once against that index pair in `src/guiding_center_3d/guiding_center_3d_constraints.jl`.
+
+
+## Choosing the constraint pair
+
+Any two of the three ``g^{k}`` confine the solution to the same manifold, and the choice is not free in practice. Requiring ``\dot{g}_{1} = \dot{g}_{2} = 0`` determines the two Lagrange multipliers as (Eq. 10)
+```math
+\lambda_{1} = \frac{\{ g_{2} , H \}}{\{ g_{1} , g_{2} \}} ,
+\qquad
+\lambda_{2} = - \frac{\{ g_{1} , H \}}{\{ g_{1} , g_{2} \}} ,
+```
+and the Poisson bracket in the denominator evaluates to (Eq. 22)
+```math
+\{ g_{1} , g_{2} \} = b_{m} \left[ \vert B \vert + (p - A) \cdot (\nabla \times b) \right] ,
+```
+where ``m`` is the index of the constraint the pair leaves out. So each pair is singular on the surface where one particular component of ``b`` vanishes:
+
+| `constraints` | pair | singular where |
+|---|---|---|
+| `:g31` | ``(g^{3}, g^{1})`` | ``b_{1} = 0`` |
+| `:g12` | ``(g^{1}, g^{2})`` | ``b_{3} = 0`` |
+| `:g23` | ``(g^{2}, g^{3})`` | ``b_{2} = 0`` |
+
+This is not a fine point. In cylindrical coordinates ``b_{1} = b_{R}`` vanishes on the midplane of an axisymmetric equilibrium, which is exactly where most of the initial conditions in this package sit: seven of the eleven equilibria that ship an initial condition have ``b_{1} = 0`` there exactly, and `SolovevSymmetricField` has ``b_{1} = b_{3} = 0`` at once, leaving `:g23` as its only usable pair. The package once implemented ``(g^{3}, g^{1})`` alone and could not be started on any of them.
+
+Every problem constructor therefore takes a `constraints` keyword, and every equilibrium declares its own `default_constraints` that is regular at its own initial conditions:
+
+```julia
+hodeproblem(initial_conditions_barely_passing())                      # the equilibrium's own pair
+hodeproblem(initial_conditions_barely_passing(); constraints = :g12)  # ⟨g¹, g²⟩, singular at b₃ = 0
+```
+
+The symbol is resolved once, in the constructor, into the `Val`-based pair `constraint_pair` returns, so the right-hand side stays specialised on it. There is deliberately no run-time switching between pairs along an orbit. `scripts/study_guiding_center_3d_conditioning.jl` tabulates the conditioning of all three pairs for every equilibrium.
+
+``b_{m} \ne 0`` at the initial condition is only the entry requirement. Along the orbit, how large ``b_{m}`` is decides how well the *omitted* constraint is conserved. The identity
+```math
+b_{1} g^{2} - b_{2} g^{1} + b_{3} g^{3} = b \cdot (b \times v) = 0
+```
+holds pointwise, so the omitted constraint is the retained pair divided by ``b_{m}``:
+```math
+\vert g_{\mathrm{omitted}} \vert \lesssim \frac{\max \vert g_{\mathrm{retained}} \vert}{\min \vert b_{m} \vert} ,
+```
+with the minimum over the orbit. On `TokamakMediumCartesian` with `:g31` the retained pair holds to ``2 \times 10^{-9}`` over a thousand steps while the omitted ``g^{2}`` reaches ``1.4 \times 10^{-6}``, because the orbit passes through ``b_{1} = 3.5 \times 10^{-4}``. Nothing is wrong there — the numerical flow enforces the pair it was given — but it is the reason `compute_constraints` reports all three components.
+
+Where ``b_{m}`` gets small enough, the whole solution goes, not just the omitted constraint. `Dipole3d` is the case in this package: all three pairs are regular at its initial condition, but its orbit takes ``b_{1}`` and ``b_{2}`` through zero, and the two pairs that divide by them hold the constraints to ``10^{-3}`` rather than ``10^{-8}`` over a hundred steps and lose the orbit altogether by ``t = 30``. Its `default_constraints` is therefore chosen on the conditioning of the pair along the orbit; the other ten are chosen on regularity at the initial condition, which is a weaker criterion. `scripts/study_guiding_center_3d_conditioning.jl` §2 measures both.
+
+
+## The three formulations
+
+Dirac's theory gives three equivalent systems, and this package builds all three.
+
+### Hamilton-Dirac — `hodeproblem`, Eq. (11)
+
+With the multipliers substituted, the constraints are imposed only through the initial condition and the dynamics is an ordinary differential equation,
 ```math
 \begin{aligned}
 \dot{r} (t) &= + \dfrac{\partial H}{\partial p} + \lambda_{1} \dfrac{\partial g_{1}}{\partial p} + \lambda_{2} \dfrac{\partial g_{2}}{\partial p} , \\
 \dot{p} (t) &= - \dfrac{\partial H}{\partial r} - \lambda_{1} \dfrac{\partial g_{1}}{\partial r} - \lambda_{2} \dfrac{\partial g_{2}}{\partial r} ,
 \end{aligned}
 ```
-where the Lagrange multipliers ``\lambda_{1}`` and ``\lambda_{2}`` are determined algebraically by requiring ``\dot{g}_{1} = \dot{g}_{2} = 0``.
-Since the multipliers are explicit functions of ``(r,p)``, this is a Hamiltonian system in the sense of a [`HODEProblem`](https://juliagni.github.io/GeometricEquations.jl/stable/), constructed by `hodeproblem`.
+which is a Hamiltonian system in the sense of a [`HODEProblem`](https://juliagni.github.io/GeometricEquations.jl/stable/). Its flow preserves ``H`` and all three ``g^{k}`` exactly, and the restriction to the constraint manifold is symplectic — which is why an ordinary symplectic Runge-Kutta method applied to it is *approximately* symplectic, with the defect bounded by the constraint drift.
 
-
-## Canonicalised Formulation
+### Canonicalised — `hodeproblem_canonical`, Eq. (13)
 
 The multipliers can alternatively be absorbed into the Hamiltonian,
 ```math
-\bar{H} (r,p) = H (r,p) + \lambda_{1} (r,p) \, g_{1} (r,p) + \lambda_{2} (r,p) \, g_{2} (r,p) ,
+\tilde{H} (r,p) = H (r,p) + \lambda_{1} (r,p) \, g_{1} (r,p) + \lambda_{2} (r,p) \, g_{2} (r,p) ,
 ```
-which agrees with ``H`` on the constraint manifold ``g_{1} = g_{2} = 0``.
-Differentiating ``\bar{H}`` produces additional terms proportional to the constraints,
+which agrees with ``H`` on the constraint manifold. Differentiating ``\tilde{H}`` adds terms proportional to the constraints,
 ```math
 \begin{aligned}
 \dot{r} (t) &= \dfrac{\partial H}{\partial p} + \lambda_{1} \dfrac{\partial g_{1}}{\partial p} + \lambda_{2} \dfrac{\partial g_{2}}{\partial p} + \dfrac{\partial \lambda_{1}}{\partial p} g_{1} + \dfrac{\partial \lambda_{2}}{\partial p} g_{2} , \\
 \dot{p} (t) &= - \dfrac{\partial H}{\partial r} - \lambda_{1} \dfrac{\partial g_{1}}{\partial r} - \lambda_{2} \dfrac{\partial g_{2}}{\partial r} - \dfrac{\partial \lambda_{1}}{\partial r} g_{1} - \dfrac{\partial \lambda_{2}}{\partial r} g_{2} ,
 \end{aligned}
 ```
-which vanish for exact initial data but not for a numerical solution that drifts off the constraint manifold.
-This genuinely canonical system is constructed by `hodeproblem_canonical`, whose Hamiltonian is ``\bar{H}``; it requires the second derivatives of the magnetic field and is correspondingly more expensive to evaluate.
+which vanish for exact initial data but not for a numerical solution that has drifted off the manifold. This system is genuinely canonical, so a symplectic method applied to it is symplectic exactly. The price is the second derivatives of the field, needed for ``\partial \lambda / \partial r`` and ``\partial \lambda / \partial p``, and a right-hand side that amplifies rather than ignores the constraint drift. It is by a wide margin the most expensive of the three — nine to thirty times the Hamilton-Dirac form per step, the wide spread coming from the harder nonlinear solve as much as from the right-hand side — and the least robust: at the step sizes the test suite uses it conserves energy and the constraints two to three orders of magnitude *worse* than the form it was derived from, and on `SolovevSymmetricField` it is the one formulation that cannot complete an orbit at all. Section 3 of `scripts/study_guiding_center_3d_conditioning.jl` has the numbers.
+
+### Compact — `hodeproblem_compact`, Eq. (29)
+
+Rearranged, the Hamilton-Dirac right-hand side splits into a part that is regular where ``b_{m} = 0`` and a part proportional to the constraints ``g^{j}``, which vanish along the solution. Dropping the latter removes most of the singularity, and is the second of the paper's two remedies for it. Not all of it, as it turns out: what Eq. (29) is left with still divides by ``b_{m}`` once, in the factor ``(p_{m} - A_{m}) / b_{m}``. Removing that too is what makes the implementation here depart from the paper; see below.
+
+Eq. (29) as printed cannot be ported here. It is written with cartesian vector identities — ``\nabla \times b``, ``b \times \nabla B`` — and with ``H = \tfrac{1}{2} \sum_{i} (p_{i} - A_{i})^{2}``, whereas eight of the thirteen equilibria in this package are curvilinear and its Hamiltonian carries ``g^{11}, g^{22}, g^{33}``. The implementation therefore derives the same system from the model's own objects, coordinate-generally. The derivation is recorded in full at the top of `src/guiding_center_3d/guiding_center_3d_compact.jl`; in outline:
+
+* Written in the antisymmetric labelling ``c = b \times v``, the momentum derivative of a constraint is
+  ```math
+  \frac{\partial c_{k}}{\partial p_{l}} = \varepsilon_{kal} \, b_{a} ,
+  ```
+  with no metric in it.
+* For the pair retaining ``(c_{i}, c_{j})``, the cyclic complement of ``m``, the multiplier contribution to ``\dot{r}`` collapses to
+  ```math
+  C_{l} = \sum_{k} \lambda^{k} \frac{\partial c_{k}}{\partial p_{l}}
+        = - \frac{b_{m} \, \{ c_{l} , H \}}{\{ c_{i} , c_{j} \}}
+  ```
+  uniformly in ``l``. For ``l \in \{i, j\}`` that is exact algebra; for ``l = m`` it needs ``\sum_{l} b_{l} c_{l} = b \cdot (b \times v) = 0``, which holds identically and hence gives ``\sum_{l} b_{l} \{ c_{l}, H \} = 0`` on the constraint manifold. That identity is the one thing Eq. (29) uses the constraints for.
+* Since ``\{ c_{i}, c_{j} \} = b_{m} D`` with the same ``D`` for all three ``m``, the singular factor ``b_{m} / \{ c_{i}, c_{j} \}`` may be replaced by ``1/D`` with
+  ```math
+  D = \frac{\sum_{m} b_{m} \, \{ c_{i} , c_{j} \}(m)}{\sum_{m} b_{m} b_{m}} ,
+  ```
+  whose denominator cannot vanish because ``\vert b \vert = 1``. This is `compact_denominator`, and in a cartesian chart it reduces to ``\vert B \vert + (p-A) \cdot (\nabla \times b)`` as it should.
+* The momentum equation follows the same way. Splitting ``\partial c_{k} / \partial q_{l}`` into its ``\partial b / \partial x`` and ``\partial A / \partial x`` parts, the second contracts straight back into ``C``, and the first does too once ``v_{a} = u \, b_{a}`` is used on the manifold. What is left is
+  ```math
+  \dot{r}_{l} = \frac{\partial H}{\partial p_{l}} + C_{l} ,
+  \qquad
+  \dot{p}_{l} = - \frac{\partial H}{\partial q_{l}} + \sum_{a} \left( \frac{\partial A_{a}}{\partial x_{l}} + u \, \frac{\partial b_{a}}{\partial x_{l}} \right) C_{a} .
+  ```
+
+Two things about this are worth stating plainly, because they are departures from the paper rather than restatements of it.
+
+First, **the compact form is independent of the constraint pair.** Eq. (29) depends on the pair only through the factor ``(p_{m} - A_{m}) / b_{m}``, which is the parallel velocity in three different spellings, all equal on the constraint manifold. Using ``u = b \cdot v`` — the `u(t, q, p)` the model already has, regular everywhere — makes the dependence disappear. This is what `constraints = :parallel`, the default of `hodeproblem_compact`, selects.
+
+Second, **the literal Eq. (29) is still singular.** ``(p_{m} - A_{m}) / b_{m}`` is ``0/0`` exactly where the pair was singular to begin with, so the ``\nu_{j}`` and ``\omega_{j}`` terms are not the only obstruction. Passing `:g31`, `:g12` or `:g23` to `hodeproblem_compact` reproduces the paper's expressions for that pair, singularity included; section 1 of `scripts/study_guiding_center_3d_conditioning.jl` shows both side by side.
+
+The equivalence is pinned by a test: `test/structure_tests.jl` spells Eq. (29) out directly from the injected field functions for the three cartesian equilibria — including `QuadraticPotentials3d`, the one with a non-zero electrostatic potential — and checks it against `guiding_center_3d_compact_v`/`_f` to round-off.
+
+On cost, the literal form is the cheapest of the three formulations, 0.86 to 0.95 of the Hamilton-Dirac form per step across the eleven equilibria: it replaces the two multipliers by a single bracket ratio and needs no second derivatives at all. The regularisation costs about half as much again, because ``D`` averages the bracket over all three ``m`` and so evaluates nine bracket terms where the literal form evaluates three. That leaves `:parallel` at 1.2 to 1.45 times the Hamilton-Dirac form — a cheap price for never dividing by a component of ``b``, and an order of magnitude below the canonicalised system.
+
+
+## Which symbol is which
+
+| source | equation |
+|---|---|
+| `gᵏ(Val(k), t, q, p)` | ``g^{k}``, Eqs. (4) and (5); `g₁`, `g₂`, `g₃` are the three fixed values |
+| `cₗ(Val(l), t, q, p)` | ``c_{l} = (b \times v)_{l}``, the same three in antisymmetric labelling |
+| `dgᵏdqₗ`, `dgᵏdpₗ`, `d²gᵏdqₗdqₘ`, `d²gᵏdqₗdpₘ` | the derivatives of ``g^{k}``; ``\partial^{2} g^{k} / \partial p \partial p`` vanishes identically |
+| `bracket_gg`, `bracket_gH` | ``\{ g^{i}, g^{j} \}`` and ``\{ g^{k}, H \}``, Eqs. (22) and (23) |
+| `λₒ`, `λ₁`, `λ₂` | ``\{ g_{1}, g_{2} \}`` and the two multipliers, Eq. (10) |
+| `dλ₁dqⱼ`, `dλ₁dpⱼ`, `dλ₂dqⱼ`, `dλ₂dpⱼ` | the multiplier gradients of Eq. (12) |
+| `bracket_cH`, `bracket_cc` | ``\{ c_{l}, H \}`` and ``\{ c_{i}, c_{j} \}``, the compact form's ingredients |
+| `compact_denominator` | ``D``, Eq. (24) |
+| `compact_multipliers` | ``C_{l}``, the multiplier contribution to ``\dot{r}``, all three at once |
+| `constraint_pair`, `compact_index` | the `constraints` keyword resolved to indices |
 
 
 ## Usage
 
 Each equilibrium is wrapped in its own module, which injects the magnetic field code and provides
-`initial_conditions` for converting ``(r,u)`` into ``(r,p)`` as well as `hodeproblem` and `hodeproblem_canonical`:
+`initial_conditions` for converting ``(r,u)`` into ``(r,p)`` as well as `hodeproblem`,
+`hodeproblem_canonical` and `hodeproblem_compact`:
 
 ```julia
 using GeometricIntegrators
@@ -79,6 +194,9 @@ using ChargedParticleDynamics.GuidingCenter3d.Dipole3d
 problem = hodeproblem(initial_conditions_dipole())
 solution = integrate(problem, PartitionedGauss(1))
 ```
+
+`compute_constraints(solution)` returns all three ``g^{k}`` along the orbit, whichever pair the
+problem retained, since all three vanish along the exact flow.
 
 
 ## Modules
@@ -89,10 +207,11 @@ ChargedParticleDynamics.GuidingCenter3d
 
 Each equilibrium is its own module, and every one of them `include`s the same
 `guiding_center_3d_equations.jl`, `guiding_center_3d_canonical.jl` and
-`guiding_center_3d_diagnostics.jl`. The model's functions are therefore documented once, below,
-under `TokamakSmallCylindrical`, and hold verbatim for all thirteen. What differs between the
-modules is the chart, the equilibrium parameters and the initial conditions, which is what these
-docstrings record:
+`guiding_center_3d_diagnostics.jl` — the first of which pulls in
+`guiding_center_3d_constraints.jl` and the second `guiding_center_3d_compact.jl`. The model's
+functions are therefore documented once, below, under `TokamakSmallCylindrical`, and hold verbatim
+for all thirteen. What differs between the modules is the chart, the equilibrium parameters, the
+initial conditions and the constraint pair they default to, which is what these docstrings record:
 
 ```@docs
 ChargedParticleDynamics.GuidingCenter3d.Dipole3d

--- a/docs/src/guiding_center_3d.md
+++ b/docs/src/guiding_center_3d.md
@@ -61,15 +61,17 @@ Any two of the three ``g^{k}`` confine the solution to the same manifold, and th
 ```
 and the Poisson bracket in the denominator evaluates to (Eq. 22)
 ```math
-\{ g_{1} , g_{2} \} = b_{m} \left[ \vert B \vert + (p - A) \cdot (\nabla \times b) \right] ,
+\{ g_{1} , g_{2} \} = \pm \, b_{m} \left[ \vert B \vert + (p - A) \cdot (\nabla \times b) \right] ,
 ```
 where ``m`` is the index of the constraint the pair leaves out. So each pair is singular on the surface where one particular component of ``b`` vanishes:
 
-| `constraints` | pair | singular where |
-|---|---|---|
-| `:g31` | ``(g^{3}, g^{1})`` | ``b_{1} = 0`` |
-| `:g12` | ``(g^{1}, g^{2})`` | ``b_{3} = 0`` |
-| `:g23` | ``(g^{2}, g^{3})`` | ``b_{2} = 0`` |
+| `constraints` | pair | ``\{ g_{1}, g_{2} \}`` | singular where |
+|---|---|---|---|
+| `:g31` | ``(g^{3}, g^{1})`` | ``+ b_{1} [ \cdots ]`` | ``b_{1} = 0`` |
+| `:g12` | ``(g^{1}, g^{2})`` | ``+ b_{3} [ \cdots ]`` | ``b_{3} = 0`` |
+| `:g23` | ``(g^{2}, g^{3})`` | ``- b_{2} [ \cdots ]`` | ``b_{2} = 0`` |
+
+The sign follows the pair's ordering, not the physics: in the antisymmetric labelling ``c_{k}`` below the bracket over a cyclic pair is ``+ b_{m} [ \cdots ]``, and ``(g^{2}, g^{3})`` is the one pair whose ordering here reverses that cycle. Reversing a pair flips ``\lambda_{\mathrm{o}}`` and both multipliers together, and the products ``\lambda_{1} \partial g_{1} + \lambda_{2} \partial g_{2}`` are unchanged, so only ``\lambda_{\mathrm{o}} = 0`` matters. It is worth stating because ``\lambda_{\mathrm{o}}`` and ``b_{m}`` then do not always share a sign, as the tabulated values in [Findings](@ref) show.
 
 This is not a fine point. In cylindrical coordinates ``b_{1} = b_{R}`` vanishes on the midplane of an axisymmetric equilibrium, which is exactly where most of the initial conditions in this package sit: seven of the eleven equilibria that ship an initial condition have ``b_{1} = 0`` there exactly, and `SolovevSymmetricField` has ``b_{1} = b_{3} = 0`` at once, leaving `:g23` as its only usable pair. The package once implemented ``(g^{3}, g^{1})`` alone and could not be started on any of them.
 
@@ -123,7 +125,7 @@ which agrees with ``H`` on the constraint manifold. Differentiating ``\tilde{H}`
 \dot{p} (t) &= - \dfrac{\partial H}{\partial r} - \lambda_{1} \dfrac{\partial g_{1}}{\partial r} - \lambda_{2} \dfrac{\partial g_{2}}{\partial r} - \dfrac{\partial \lambda_{1}}{\partial r} g_{1} - \dfrac{\partial \lambda_{2}}{\partial r} g_{2} ,
 \end{aligned}
 ```
-which vanish for exact initial data but not for a numerical solution that has drifted off the manifold. This system is genuinely canonical, so a symplectic method applied to it is symplectic exactly. The price is the second derivatives of the field, needed for ``\partial \lambda / \partial r`` and ``\partial \lambda / \partial p``, and a right-hand side that amplifies rather than ignores the constraint drift. It is by a wide margin the most expensive of the three — nine to thirty times the Hamilton-Dirac form per step, the wide spread coming from the harder nonlinear solve as much as from the right-hand side — and the least robust: at the step sizes the test suite uses it conserves energy and the constraints two to three orders of magnitude *worse* than the form it was derived from, and on `SolovevSymmetricField` it is the one formulation that cannot complete an orbit at all. Section 3 of `scripts/study_guiding_center_3d_conditioning.jl` has the numbers.
+which vanish for exact initial data but not for a numerical solution that has drifted off the manifold. This system is genuinely canonical, so a symplectic method applied to it is symplectic exactly. The price is the second derivatives of the field, needed for ``\partial \lambda / \partial r`` and ``\partial \lambda / \partial p``, and a right-hand side that amplifies rather than ignores the constraint drift. It is by a wide margin the most expensive of the three — nine to nineteen times the Hamilton-Dirac form per step, the wide spread coming from the harder nonlinear solve as much as from the right-hand side — and the least robust: at the step sizes the test suite uses it gives up as much as two or three orders of magnitude of energy conservation and four or five of constraint conservation against the form it was derived from, and on `SolovevSymmetricField` it is the one formulation that cannot complete an orbit at all. Those are worst cases across the eleven equilibria rather than typical ones; on five of them it is within a factor of two on both. Section 3 of `scripts/study_guiding_center_3d_conditioning.jl` has the numbers.
 
 ### Compact — `hodeproblem_compact`, Eq. (29)
 
@@ -146,7 +148,7 @@ Eq. (29) as printed cannot be ported here. It is written with cartesian vector i
   ```math
   D = \frac{\sum_{m} b_{m} \, \{ c_{i} , c_{j} \}(m)}{\sum_{m} b_{m} b_{m}} ,
   ```
-  whose denominator cannot vanish because ``\vert b \vert = 1``. This is `compact_denominator`, and in a cartesian chart it reduces to ``\vert B \vert + (p-A) \cdot (\nabla \times b)`` as it should.
+  whose denominator cannot vanish. Not because it is one: the ``b_{i}`` are covariant components, so what is normalised is ``\sum_{i} g^{ii} b_{i} b_{i} = 1``, and ``\sum_{i} b_{i} b_{i}`` is 6.25 on the ITER Solov'ev X-point and 1.11 on the toroidal tokamak. It cannot vanish because the metric is positive definite, so the normalisation forbids every ``b_{i}`` being zero at once. A weighted mean is exact for any positive weights, so the choice of ``b_{m} b_{m}`` costs nothing in accuracy and needs nothing the model does not already have. This is `compact_denominator`, and in a cartesian chart it reduces to ``\vert B \vert + (p-A) \cdot (\nabla \times b)`` as it should.
 * The momentum equation follows the same way. Splitting ``\partial c_{k} / \partial q_{l}`` into its ``\partial b / \partial x`` and ``\partial A / \partial x`` parts, the second contracts straight back into ``C``, and the first does too once ``v_{a} = u \, b_{a}`` is used on the manifold. What is left is
   ```math
   \dot{r}_{l} = \frac{\partial H}{\partial p_{l}} + C_{l} ,
@@ -158,11 +160,20 @@ Two things about this are worth stating plainly, because they are departures fro
 
 First, **the compact form is independent of the constraint pair.** Eq. (29) depends on the pair only through the factor ``(p_{m} - A_{m}) / b_{m}``, which is the parallel velocity in three different spellings, all equal on the constraint manifold. Using ``u = b \cdot v`` — the `u(t, q, p)` the model already has, regular everywhere — makes the dependence disappear. This is what `constraints = :parallel`, the default of `hodeproblem_compact`, selects.
 
-Second, **the literal Eq. (29) is still singular.** ``(p_{m} - A_{m}) / b_{m}`` is ``0/0`` exactly where the pair was singular to begin with, so the ``\nu_{j}`` and ``\omega_{j}`` terms are not the only obstruction. Passing `:g31`, `:g12` or `:g23` to `hodeproblem_compact` reproduces the paper's expressions for that pair, singularity included; section 1 of `scripts/study_guiding_center_3d_conditioning.jl` shows both side by side.
+Second, **the literal Eq. (29) is still singular.** ``(p_{m} - A_{m}) / b_{m}`` is ``0/0`` exactly where the pair was singular to begin with, so the ``\nu_{j}`` and ``\omega_{j}`` terms are not the only obstruction.
 
-The equivalence is pinned by a test: `test/structure_tests.jl` spells Eq. (29) out directly from the injected field functions for the three cartesian equilibria — including `QuadraticPotentials3d`, the one with a non-zero electrostatic potential — and checks it against `guiding_center_3d_compact_v`/`_f` to round-off.
+Passing `:g31`, `:g12` or `:g23` to `hodeproblem_compact` exhibits that dependence, and does so in *two* places rather than one, which is worth being precise about because only one of them is the paper's:
 
-On cost, the literal form is the cheapest of the three formulations, 0.86 to 0.95 of the Hamilton-Dirac form per step across the eleven equilibria: it replaces the two multipliers by a single bracket ratio and needs no second derivatives at all. The regularisation costs about half as much again, because ``D`` averages the bracket over all three ``m`` and so evaluates nine bracket terms where the literal form evaluates three. That leaves `:parallel` at 1.2 to 1.45 times the Hamilton-Dirac form — a cheap price for never dividing by a component of ``b``, and an order of magnitude below the canonicalised system.
+| | `:parallel` | a pair symbol |
+|---|---|---|
+| multiplier scale | ``-1/D``, from `compact_denominator` | ``-b_{m} / \{ c_{i}, c_{j} \}(m)`` |
+| parallel velocity | ``u(t, q, p)`` | ``(p_{m} - A_{m}) / b_{m}`` |
+
+The second row is Eq. (29) as printed. The first is not: the paper evaluates the scale from ``D`` written out as ``\vert B \vert + (p-A) \cdot (\nabla \times b)``, which is regular everywhere, so its Eq. (29) carries one ``b_{m}`` denominator and the pair variants here carry two. Taking the scale from the pair's own bracket instead is a choice made in this implementation. Both denominators vanish on the same surface, so it changes nothing about *where* the variant is singular — but it does mean these variants are not a literal transcription, and the reason to keep them is to exhibit the pair dependence of Eq. (29), not to integrate with. Section 1 of `scripts/study_guiding_center_3d_conditioning.jl` shows the regularised and the pair-dependent denominators side by side.
+
+The equivalence is pinned by a test: `test/structure_tests.jl` spells Eq. (29) out directly from the injected field functions for the three cartesian equilibria — including `QuadraticPotentials3d`, the one with a non-zero electrostatic potential — and checks both variants against it to round-off.
+
+On cost, the pair-dependent variant is the cheapest of the three formulations, 0.86 to 0.95 of the Hamilton-Dirac form per step across the eleven equilibria: it replaces the two multipliers by a single bracket ratio and needs no second derivatives at all. That saving is exactly the choice above — one bracket rather than the three ``D`` averages — so it is not available to `:parallel`, which lands at 1.2 to 1.45 times the Hamilton-Dirac form. A cheap price for never dividing by a component of ``b``, and an order of magnitude below the canonicalised system.
 
 
 ## Which symbol is which
@@ -207,8 +218,9 @@ ChargedParticleDynamics.GuidingCenter3d
 
 Each equilibrium is its own module, and every one of them `include`s the same
 `guiding_center_3d_equations.jl`, `guiding_center_3d_canonical.jl` and
-`guiding_center_3d_diagnostics.jl` — the first of which pulls in
-`guiding_center_3d_constraints.jl` and the second `guiding_center_3d_compact.jl`. The model's
+`guiding_center_3d_diagnostics.jl` — the first of which pulls in both
+`guiding_center_3d_constraints.jl` and `guiding_center_3d_compact.jl`, since neither of those depends
+on the canonicalised system. The model's
 functions are therefore documented once, below, under `TokamakSmallCylindrical`, and hold verbatim
 for all thirteen. What differs between the modules is the chart, the equilibrium parameters, the
 initial conditions and the constraint pair they default to, which is what these docstrings record:

--- a/scripts/guiding_center_3d.jl
+++ b/scripts/guiding_center_3d.jl
@@ -28,10 +28,6 @@ p₀ = ChargedParticle3d.TokamakIterCylindrical.charged_particle_3d_pᵢ(0, x₀
 
 q₀, μ = guiding_center(ics)
 
-q3₀ = copy(q₀)
-q3₀[2] = sqrt(eps())
-q3₀
-
 parameters = (μ=μ,)
 
 # `f_abstol` is an absolute bound on the residual and has to stay above its round-off floor, which
@@ -51,7 +47,12 @@ timespan = (0., 50_000.)
 timespan_long = (0., 1_000_000.);
 
 
-g3ode = GuidingCenter3d.TokamakIterCylindrical.hodeproblem(q3₀; parameters = parameters, timestep=Δt3, timespan=timespan)#(0., 19_189.)
+# `q₀` sits on the midplane, where `b₁ = b_R = 0`. That used to be fatal — the only constraint pair
+# the model had was `(g³, g¹)`, whose Lagrange multipliers divide by `b₁` — and this script displaced
+# the initial condition off the plane by `sqrt(eps())` to work around it. `TokamakIterCylindrical`
+# now defaults to `(g¹, g²)`, which divides by `b₃ = b_φ` instead, so the physical initial condition
+# can be used as it stands.
+g3ode = GuidingCenter3d.TokamakIterCylindrical.hodeproblem(q₀; parameters = parameters, timestep=Δt3, timespan=timespan)#(0., 19_189.)
 g3sol = integrate(g3ode, PartitionedGauss(1); initialguess=NoInitialGuess(),options...)
 # g3sol = integrate(g3ode, PartitionedGauss(1); options...)
 g3car = cartesian_solution(g3sol, GuidingCenter3d.TokamakIterCylindrical);

--- a/scripts/guiding_center_3d_constraint.jl
+++ b/scripts/guiding_center_3d_constraint.jl
@@ -2,19 +2,16 @@ using GeometricIntegrators
 using SimpleSolvers: Options
 
 using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCartesian
-using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCartesian: hamiltonian, hamiltonian_u, g₁, g₂, λₒ, λ₁, λ₂, b₁, b₂, b₃
-using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCartesian: dg₁dq₁, dg₁dq₂, dg₁dq₃, dg₁dp₁, dg₁dp₂, dg₁dp₃
-using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCartesian: dg₂dp₁, dg₂dp₂, dg₂dp₃, dg₂dq₁, dg₂dq₂, dg₂dq₃
+using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCartesian: hamiltonian, hamiltonian_u, g₁, g₂, g₃, λₒ, λ₁, λ₂, b₁, b₂, b₃
+using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCartesian: gᵏ, dgᵏdqₗ, dgᵏdpₗ, constraint_pair, default_constraints
 
 # using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical
-# using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical: hamiltonian, hamiltonian_u, g₁, g₂, λₒ, λ₁, λ₂, b₁, b₂, b₃
-# using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical: dg₁dq₁, dg₁dq₂, dg₁dq₃, dg₁dp₁, dg₁dp₂, dg₁dp₃
-# using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical: dg₂dp₁, dg₂dp₂, dg₂dp₃, dg₂dq₁, dg₂dq₂, dg₂dq₃
+# using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical: hamiltonian, hamiltonian_u, g₁, g₂, g₃, λₒ, λ₁, λ₂, b₁, b₂, b₃
+# using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical: gᵏ, dgᵏdqₗ, dgᵏdpₗ, constraint_pair, default_constraints
 
 # using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal
-# using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal: hamiltonian, hamiltonian_u, g₁, g₂, λₒ, λ₁, λ₂, b₁, b₂, b₃
-# using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal: dg₁dq₁, dg₁dq₂, dg₁dq₃, dg₁dp₁, dg₁dp₂, dg₁dp₃
-# using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal: dg₂dp₁, dg₂dp₂, dg₂dp₃, dg₂dq₁, dg₂dq₂, dg₂dq₃
+# using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal: hamiltonian, hamiltonian_u, g₁, g₂, g₃, λₒ, λ₁, λ₂, b₁, b₂, b₃
+# using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal: gᵏ, dgᵏdqₗ, dgᵏdpₗ, constraint_pair, default_constraints
 
 # `f_abstol` is an absolute bound on the residual and has to stay above its round-off floor, which
 # for these models is `‖ϑ‖ eps`. The 1E-14 this script used to ask for is below it, so the solver
@@ -37,10 +34,17 @@ hu = [hamiltonian_u(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in each
 λ2 = [λ₂(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in eachindex(sol.t)]
 g1 = [g₁(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 g2 = [g₂(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
+g3 = [g₃(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 b1 = [b₁(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b2 = [b₂(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b3 = [b₃(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 
+# The pair the problem above was built with, in the order the multipliers see it. `λ₁` divides
+# `{g₂, H}` and `λ₂` divides `-{g₁, H}` by `λₒ = {g₁, g₂}`, where `g₁` and `g₂` mean these two.
+const c = constraint_pair(default_constraints())
+
+println()
+println("constraint pair = ", default_constraints(), "  ", c)
 println()
 println("q(0) = ", sol.q[begin])
 println("q(T) = ", sol.q[end])
@@ -51,17 +55,20 @@ println()
 println("H(0) = ", h[begin], ", ", hu[begin])
 println("H(T) = ", h[end], ", ", hu[end])
 println()
-println("g₁(0) = ", g1[begin])
-println("g₁(T) = ", g1[end])
-println()
-println("g₂(0) = ", g2[begin])
-println("g₂(T) = ", g2[end])
+
+# All three vanish along the exact flow, whichever two the pair retains, so all three are worth
+# printing: a drift that cancels in the retained pair still shows up in the third.
+println("g¹(0) = ", g1[begin], "   g¹(T) = ", g1[end])
+println("g²(0) = ", g2[begin], "   g²(T) = ", g2[end])
+println("g³(0) = ", g3[begin], "   g³(T) = ", g3[end])
 println()
 println("λ₀(0) = ", λ0[begin])
 println("λ₀(T) = ", λ0[end])
 println()
-println("λ₁(0) * g₁(0) + λ₂(0) * g₂(0) = ", λ1[begin] * g1[begin] + λ2[begin] * g2[begin])
-println("λ₁(T) * g₁(T) + λ₂(T) * g₂(T) = ", λ1[end] * g1[end] + λ2[end] * g2[end])
+println("λ₁ g₁ + λ₂ g₂ (0) = ", λ1[begin] * gᵏ(c[1], sol.t[begin], sol.q[begin], sol.p[begin]) +
+                                λ2[begin] * gᵏ(c[2], sol.t[begin], sol.q[begin], sol.p[begin]))
+println("λ₁ g₁ + λ₂ g₂ (T) = ", λ1[end] * gᵏ(c[1], sol.t[end], sol.q[end], sol.p[end]) +
+                                λ2[end] * gᵏ(c[2], sol.t[end], sol.q[end], sol.p[end]))
 println()
 
 println()
@@ -70,26 +77,28 @@ println("b₂(x₀) = ", b2[begin])
 println("b₃(x₀) = ", b3[begin])
 println()
 
-println()
-println("dg₁dq₁(0) * dg₂dp₁(0) = ", dg₁dq₁(sol.t[begin], sol.q[begin], sol.p[begin]) * dg₂dp₁(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dq₂(0) * dg₂dp₂(0) = ", dg₁dq₂(sol.t[begin], sol.q[begin], sol.p[begin]) * dg₂dp₂(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dq₃(0) * dg₂dp₃(0) = ", dg₁dq₃(sol.t[begin], sol.q[begin], sol.p[begin]) * dg₂dp₃(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dp₁(0) * dg₂dq₁(0) = ", dg₁dp₁(sol.t[begin], sol.q[begin], sol.p[begin]) * dg₂dq₁(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dp₂(0) * dg₂dq₂(0) = ", dg₁dp₂(sol.t[begin], sol.q[begin], sol.p[begin]) * dg₂dq₂(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dp₃(0) * dg₂dq₃(0) = ", dg₁dp₃(sol.t[begin], sol.q[begin], sol.p[begin]) * dg₂dq₃(sol.t[begin], sol.q[begin], sol.p[begin]))
-println()
+# The six products that make up λₒ = Σₗ (∂g₁/∂qₗ ∂g₂/∂pₗ - ∂g₁/∂pₗ ∂g₂/∂qₗ). Which of them carry the
+# vanishing component of b is what decides whether the pair is usable at this initial condition.
+let t₀ = sol.t[begin], q₀ = sol.q[begin], p₀ = sol.p[begin]
+    println()
+    for i in 1:3
+        l = Val(i)
+        println("∂g₁/∂q$i * ∂g₂/∂p$i = ", dgᵏdqₗ(c[1], l, t₀, q₀, p₀) * dgᵏdpₗ(c[2], l, t₀, q₀, p₀))
+    end
+    for i in 1:3
+        l = Val(i)
+        println("∂g₁/∂p$i * ∂g₂/∂q$i = ", dgᵏdpₗ(c[1], l, t₀, q₀, p₀) * dgᵏdqₗ(c[2], l, t₀, q₀, p₀))
+    end
+    println()
 
-println()
-println("dg₁dq₁(0) = ", dg₁dq₁(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dq₂(0) = ", dg₁dq₂(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dq₃(0) = ", dg₁dq₃(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dp₁(0) = ", dg₁dp₁(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dp₂(0) = ", dg₁dp₂(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₁dp₃(0) = ", dg₁dp₃(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₂dp₁(0) = ", dg₂dp₁(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₂dp₂(0) = ", dg₂dp₂(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₂dp₃(0) = ", dg₂dp₃(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₂dq₁(0) = ", dg₂dq₁(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₂dq₂(0) = ", dg₂dq₂(sol.t[begin], sol.q[begin], sol.p[begin]))
-println("dg₂dq₃(0) = ", dg₂dq₃(sol.t[begin], sol.q[begin], sol.p[begin]))
-println()
+    println()
+    for (label, k) in (("g₁", c[1]), ("g₂", c[2]))
+        for i in 1:3
+            println("∂$label/∂q$i = ", dgᵏdqₗ(k, Val(i), t₀, q₀, p₀))
+        end
+        for i in 1:3
+            println("∂$label/∂p$i = ", dgᵏdpₗ(k, Val(i), t₀, q₀, p₀))
+        end
+    end
+    println()
+end

--- a/scripts/guiding_center_3d_dipole.jl
+++ b/scripts/guiding_center_3d_dipole.jl
@@ -2,9 +2,7 @@ using GeometricIntegrators
 using SimpleSolvers
 
 using ChargedParticleDynamics.GuidingCenter3d.Dipole3d
-using ChargedParticleDynamics.GuidingCenter3d.Dipole3d: hamiltonian, hamiltonian_u, g₁, g₂, λₒ, λ₁, λ₂, b₁, b₂, b₃
-using ChargedParticleDynamics.GuidingCenter3d.Dipole3d: dg₁dq₁, dg₁dq₂, dg₁dq₃, dg₁dp₁, dg₁dp₂, dg₁dp₃
-using ChargedParticleDynamics.GuidingCenter3d.Dipole3d: dg₂dp₁, dg₂dp₂, dg₂dp₃, dg₂dq₁, dg₂dq₂, dg₂dq₃
+using ChargedParticleDynamics.GuidingCenter3d.Dipole3d: hamiltonian, hamiltonian_u, g₁, g₂, g₃, λₒ, λ₁, λ₂, b₁, b₂, b₃
 
 const options = (f_abstol=8eps(), verbosity=1)
 
@@ -30,6 +28,7 @@ hu = [hamiltonian_u(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in each
 λ2 = [λ₂(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in eachindex(sol.t)]
 g1 = [g₁(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 g2 = [g₂(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
+g3 = [g₃(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 b1 = [b₁(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b2 = [b₂(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b3 = [b₃(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
@@ -54,6 +53,9 @@ println("g₁(T) = ", g1[end])
 println()
 println("g₂(0) = ", g2[begin])
 println("g₂(T) = ", g2[end])
+
+println("g₃(0) = ", g3[begin])
+println("g₃(T) = ", g3[end])
 println()
 println("λ₀(0) = ", λ0[begin])
 println("λ₀(T) = ", λ0[end])

--- a/scripts/guiding_center_3d_quadratic_potentials.jl
+++ b/scripts/guiding_center_3d_quadratic_potentials.jl
@@ -1,9 +1,7 @@
 using GeometricIntegrators
 
 using ChargedParticleDynamics.GuidingCenter3d.QuadraticPotentials3d
-using ChargedParticleDynamics.GuidingCenter3d.QuadraticPotentials3d: hamiltonian, hamiltonian_u, g₁, g₂, λₒ, λ₁, λ₂, b₁, b₂, b₃
-using ChargedParticleDynamics.GuidingCenter3d.QuadraticPotentials3d: dg₁dq₁, dg₁dq₂, dg₁dq₃, dg₁dp₁, dg₁dp₂, dg₁dp₃
-using ChargedParticleDynamics.GuidingCenter3d.QuadraticPotentials3d: dg₂dp₁, dg₂dp₂, dg₂dp₃, dg₂dq₁, dg₂dq₂, dg₂dq₃
+using ChargedParticleDynamics.GuidingCenter3d.QuadraticPotentials3d: hamiltonian, hamiltonian_u, g₁, g₂, g₃, λₒ, λ₁, λ₂, b₁, b₂, b₃
 
 const options = (f_abstol=2eps(), verbosity=1)
 
@@ -35,6 +33,7 @@ hu = [hamiltonian_u(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in each
 λ2 = [λ₂(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in eachindex(sol.t)]
 g1 = [g₁(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 g2 = [g₂(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
+g3 = [g₃(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 b1 = [b₁(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b2 = [b₂(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b3 = [b₃(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
@@ -59,6 +58,9 @@ println("g₁(T) = ", g1[end])
 println()
 println("g₂(0) = ", g2[begin])
 println("g₂(T) = ", g2[end])
+
+println("g₃(0) = ", g3[begin])
+println("g₃(T) = ", g3[end])
 println()
 println("λ₀(0) = ", λ0[begin])
 println("λ₀(T) = ", λ0[end])

--- a/scripts/guiding_center_3d_tokamak.jl
+++ b/scripts/guiding_center_3d_tokamak.jl
@@ -1,9 +1,7 @@
 using GeometricIntegrators
 
 using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian
-using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian: hamiltonian, hamiltonian_u, g₁, g₂, λₒ, λ₁, λ₂, b₁, b₂, b₃
-using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian: dg₁dq₁, dg₁dq₂, dg₁dq₃, dg₁dp₁, dg₁dp₂, dg₁dp₃
-using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian: dg₂dp₁, dg₂dp₂, dg₂dp₃, dg₂dq₁, dg₂dq₂, dg₂dq₃
+using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian: hamiltonian, hamiltonian_u, g₁, g₂, g₃, λₒ, λ₁, λ₂, b₁, b₂, b₃
 
 # See `guiding_center_3d_constraint.jl` for why `f_abstol` cannot be pushed to the round-off floor:
 # `2eps()` leaves the solver no reachable stopping criterion on these models.
@@ -30,6 +28,7 @@ hu = [hamiltonian_u(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in each
 λ2 = [λ₂(sol.t[i], sol.q[i], sol.p[i], parameters(equ)) for i in eachindex(sol.t)]
 g1 = [g₁(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 g2 = [g₂(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
+g3 = [g₃(sol.t[i], sol.q[i], sol.p[i]) for i in eachindex(sol.t)]
 b1 = [b₁(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b2 = [b₂(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
 b3 = [b₃(sol.t[i], sol.q[i]) for i in eachindex(sol.t)]
@@ -54,6 +53,9 @@ println("g₁(T) = ", g1[end])
 println()
 println("g₂(0) = ", g2[begin])
 println("g₂(T) = ", g2[end])
+
+println("g₃(0) = ", g3[begin])
+println("g₃(T) = ", g3[end])
 println()
 println("λ₀(0) = ", λ0[begin])
 println("λ₀(T) = ", λ0[end])

--- a/scripts/study_guiding_center_3d_conditioning.jl
+++ b/scripts/study_guiding_center_3d_conditioning.jl
@@ -1,25 +1,49 @@
 #
-# How well conditioned is the constrained canonical guiding centre model?
+# How well conditioned is the constrained canonical guiding centre model, and does the choice of
+# constraint formulation matter?
 #
 # The 3D model replaces the parallel-velocity constraint by two of the three independent components
 # of v × b = 0. Li, Zhang & Liu label them
 #
 #     g¹ = b₁ v₃ - b₃ v₁,    g² = b₂ v₃ - b₃ v₂,    g³ = b₁ v₂ - b₂ v₁
 #
-# and show that the Poisson bracket in the denominator of both Lagrange multipliers is
-# b₃ [B + (p-A)·(∇×b)] for the pair (g¹, g²) and b₁ [ ... ] for the pair (g¹, g³).
+# and show that the Poisson bracket {g₁, g₂} in the denominator of both Lagrange multipliers carries
+# a factor of the b-component belonging to the constraint the pair leaves out:
 #
-# This package uses (g³, g¹), so the multipliers are singular where b₁ = 0. In cylindrical
-# coordinates b₁ = b_R, which vanishes on the midplane of an axisymmetric equilibrium — exactly
-# where the supplied initial conditions sit. This script measures how close to that the shipped
-# initial conditions are, and what it does to the multipliers.
+#     pair (g³, g¹) → b₁ [B + (p-A)·(∇×b)]     selected by  constraints = :g31
+#     pair (g¹, g²) → b₃ [ ... ]                            constraints = :g12
+#     pair (g², g³) → b₂ [ ... ]                            constraints = :g23
 #
-# See docs/src/findings.md, "Conditioning of the 3D guiding centre constraint pair".
+# The package used to implement only (g³, g¹), so it was singular wherever b₁ = 0. In cylindrical
+# coordinates b₁ = b_R, which vanishes on the midplane of an axisymmetric equilibrium — exactly where
+# the supplied initial conditions sit — and seven of the eleven equilibria below could not be started
+# at all. All three pairs are now available, and each equilibrium declares a `default_constraints`
+# that is regular at its own initial conditions.
+#
+# On top of the choice of pair there is the choice of formulation: the Hamilton-Dirac equations
+# (`hodeproblem`, Eq. 11), the canonicalised system with the extended Hamiltonian
+# (`hodeproblem_canonical`, Eq. 13), and the compact form that drops the constraint-proportional
+# terms from the right-hand side (`hodeproblem_compact`, Eq. 29). The last of these is regular
+# everywhere and does not depend on the pair at all; see the derivation at the top of
+# `src/guiding_center_3d/guiding_center_3d_compact.jl`.
+#
+# Section 1 measures the conditioning of each pair at each equilibrium's initial condition, section 2
+# checks that the formulations agree wherever they are all usable, and section 3 measures what each
+# one costs.
+#
+# See docs/src/findings.md, "Conditioning of the 3D guiding centre constraint formulations".
+#
+# Sections 2 and 3 integrate every equilibrium with every variant, and each variant is a distinct
+# specialisation of the integrator, so most of the wall clock is compilation: expect several minutes.
+# The script flushes after each equilibrium so progress is visible when its output is redirected.
 #
 # Run with:  julia --project=scripts scripts/study_guiding_center_3d_conditioning.jl
 #
 
 using ChargedParticleDynamics
+using GeometricIntegrators
+using LinearAlgebra
+using Logging
 using Printf
 
 const G3 = ChargedParticleDynamics.GuidingCenter3d
@@ -36,53 +60,322 @@ const CASES = (("Dipole3d",                "cartesian",   G3.Dipole3d,          
                ("SolovevSymmetricField",   "cylindrical", G3.SolovevSymmetricField,   :initial_conditions_barely_passing),
                ("TokamakSmallToroidal",    "toroidal",    G3.TokamakSmallToroidal,    :initial_conditions_barely_passing))
 
-function main()
+const PAIRS = (:g31, :g12, :g23)
+
+# The tolerance the test suite settled on; see the comment on `options` in
+# `test/guiding_center_3d_tests.jl`.
+const OPTIONS = (f_abstol = 1E-12, max_iterations = 50)
+
+const METHOD = PartitionedGauss(2)
+
+# A hundred steps at the smaller of the equilibrium's own `DEFAULT_TIMESTEP` and 0.1, which is the
+# workload the test suite uses. Neither bound can be dropped. A single step size across all eleven is
+# not usable — forcing Δt = 0.1 on the dipole, whose natural step is 0.03, makes every formulation
+# diverge, which says something about that step size and nothing about the formulations. But taking
+# each equilibrium's own step is not usable either: `TokamakSmallCartesian` integrates at Δt = 200,
+# where every solve is stiff enough that its six variants alone outlast the whole rest of this script.
+const NSTEPS = 100
+
+workload(M) = (timespan = (0.0, NSTEPS * min(M.DEFAULT_TIMESTEP, 0.1)),
+               timestep = min(M.DEFAULT_TIMESTEP, 0.1))
+
+mean(x) = isempty(x) ? 0.0 : sum(x) / length(x)
+
+# `DataSeries` is indexable but not an iterator, so `maximum(abs, ds)` does not work on one.
+mx(ds) = maximum(abs(ds[i]) for i in eachindex(ds))
+
+# every GuidingCenter3d `initial_conditions_*` returns a NamedTuple (q, p, params)
+initial(M, icsname) = getfield(M, icsname)()
+
+
+# ---------------------------------------------------------------------------------------------
+# A logger that harvests the iteration count out of the "Solver took N iterations." warnings, as in
+# `study_solver_tolerances.jl`. `SimpleSolvers` emits one per solve that reaches `warn_iterations`,
+# so `warn_iterations=1` turns the warning into a per-solve report of the work a step cost.
+# ---------------------------------------------------------------------------------------------
+
+mutable struct IterationLogger <: AbstractLogger
+    iterations::Vector{Int}
+end
+
+Logging.shouldlog(::IterationLogger, level, _module, group, id) = true
+Logging.min_enabled_level(::IterationLogger) = Logging.Debug
+Logging.catch_exceptions(::IterationLogger) = false
+
+function Logging.handle_message(logger::IterationLogger, level, message, _module, group, id,
+                                file, line; kwargs...)
+    m = match(r"Solver took (\d+) iterations", string(message))
+    m === nothing || push!(logger.iterations, parse(Int, m.captures[1]))
+    nothing
+end
+
+const ITERLOG = IterationLogger(Int[])
+
+
+# ---------------------------------------------------------------------------------------------
+# 1. Conditioning of the three pairs
+# ---------------------------------------------------------------------------------------------
+
+function conditioning()
     println("""
+    1. Conditioning of the three constraint pairs
+    =============================================
+
     At the shipped initial condition of each equilibrium:
 
-      b₁    the component whose vanishing makes the active constraint pair (g³, g¹) singular
-      λₒ    the Poisson bracket {g₃, g₁} that divides both Lagrange multipliers
-      λ₁,λ₂ the multipliers themselves
+      b₁ b₂ b₃   the components of b in that equilibrium's chart; the pair omitting gᵏ divides by bₖ
+      λₒ         the Poisson bracket {g₁, g₂} that divides both Lagrange multipliers, per pair
+      D          the same bracket as the compact form computes it, Σₘ bₘ {cᵢ,cⱼ}(m) / Σₘ bₘ bₘ, which
+                 never divides by a single component and so stays finite where the pairs do not
+      default    the pair the equilibrium ships with
     """)
 
-    @printf("  %-27s %-12s %-12s %-13s %-12s %-12s\n",
-            "equilibrium", "coords", "b₁", "λₒ", "λ₁", "λ₂")
+    @printf("  %-26s %-12s %10s %10s %10s   %11s %11s %11s   %10s %8s\n",
+            "equilibrium", "coords", "b₁", "b₂", "b₃",
+            "λₒ(:g31)", "λₒ(:g12)", "λₒ(:g23)", "D", "default")
 
     for (name, coords, M, icsname) in CASES
         isdefined(M, icsname) || continue
-        # every GuidingCenter3d `initial_conditions_*` returns a NamedTuple (q, p, params)
-        ic = getfield(M, icsname)()
-        q, p, par = ic.q, ic.p, ic.params
-        t = 0.0
+        ic = initial(M, icsname)
+        q, p, t = ic.q, ic.p, 0.0
 
-        b₁ = M.b₁(t, q)
-        λₒ = M.λₒ(t, q, p)
-        λ₁ = M.λ₁(t, q, p, par)
-        λ₂ = M.λ₂(t, q, p, par)
+        λ = [M.λₒ(t, q, p, M.constraint_pair(s)) for s in PAIRS]
 
-        @printf("  %-27s %-12s %-12.3e %-13.3e %-12.3e %-12.3e\n", name, coords, b₁, λₒ, λ₁, λ₂)
+        @printf("  %-26s %-12s %10.3e %10.3e %10.3e   %11.3e %11.3e %11.3e   %10.3e %8s\n",
+                name, coords, M.b₁(t, q), M.b₂(t, q), M.b₃(t, q), λ...,
+                M.compact_denominator(t, q, p), M.default_constraints())
+    end
+    flush(stdout)
+
+    println("""
+
+    A vanishing λₒ means both multipliers are ±Inf or NaN and the problem cannot be started: the
+    Newton solver hits the NaN in its direction vector on the first step. Seven of the eleven
+    equilibria are in that position for the pair (g³, g¹) that the package used to hard-code, and
+    `SolovevSymmetricField` is in it for two of the three pairs at once — b = e₂ there, so only
+    (g², g³) survives.
+
+    Nothing about this is confined to the curvilinear equilibria. `TokamakSmallCartesian` fails for
+    (g³, g¹) too, because its initial condition sits at y = z = 0 where B_x = 0. What decides the
+    outcome is where the initial condition lies relative to the field, not the coordinate system.
+
+    The D column is the point of the compact formulation: it is finite for every equilibrium here,
+    including the ones where two of the three pairs are singular. The three ratios {cᵢ,cⱼ}(m) / bₘ
+    that it averages agree to machine precision wherever they are all defined, in every chart, which
+    is what makes the average a faithful stand-in rather than a fudge.""")
+end
+
+
+# ---------------------------------------------------------------------------------------------
+# 2. Do the formulations agree?
+# ---------------------------------------------------------------------------------------------
+
+"""
+    variants(M, ic)
+
+The variants to compare for equilibrium module `M` at initial condition `ic`, as
+`(label, regular, constructor)` triples: the Hamilton-Dirac form for each of the three pairs, the
+canonicalised form and the compact form for the equilibrium's own default pair, and the compact form
+in its regularised, pair-independent variant.
+
+`regular` says whether the variant's denominator survives the initial condition. Attempting a
+singular one is not merely useless but slow: the multipliers are infinite from the first stage, and
+the backtracking line search grinds through its thousand-iteration budget on every step before the
+solver finally reports the NaN.
+"""
+function variants(M, ic)
+    d = M.default_constraints()
+    w = workload(M)
+    q, p, t = ic.q, ic.p, 0.0
+
+    # a pair is usable where the bracket it divides by does not vanish …
+    pairok(s) = (λ = M.λₒ(t, q, p, M.constraint_pair(s)); isfinite(λ) && !iszero(λ))
+    # … and the literal compact form where the single component of b it divides by does not
+    compactok(s) = !iszero(M.bᵢ(M.compact_index(s), t, q))
+
+    (("hode :g31", pairok(:g31), ic -> M.hodeproblem(ic; constraints = :g31, w...)),
+     ("hode :g12", pairok(:g12), ic -> M.hodeproblem(ic; constraints = :g12, w...)),
+     ("hode :g23", pairok(:g23), ic -> M.hodeproblem(ic; constraints = :g23, w...)),
+     ("canonical :$d", pairok(d), ic -> M.hodeproblem_canonical(ic; w...)),
+     ("compact :$d", compactok(d), ic -> M.hodeproblem_compact(ic; constraints = d, w...)),
+     ("compact :parallel", true, ic -> M.hodeproblem_compact(ic; w...)))
+end
+
+"""
+    solve(M, ic, makeproblem)
+
+Integrate one variant and return the final state together with the invariant errors along it, or
+`nothing` if it could not be integrated at all.
+"""
+function solve(M, ic, makeproblem)
+    try
+        problem = makeproblem(ic)
+        sol = integrate(problem, METHOD; initialguess = MidpointExtrapolation(5), OPTIONS...)
+        y = vcat(sol.q[end], sol.p[end])
+        any(!isfinite, y) && return nothing
+
+        c = M.compute_constraints(sol)
+        _, e = M.compute_energy_error(sol.t, sol.q, sol.p, parameters(problem))
+
+        return (y = y,
+                energy = mx(e),
+                constraints = maximum(mx(getproperty(c, k)) for k in (:g₁, :g₂, :g₃)))
+    catch
+        return nothing
+    end
+end
+
+function agreement()
+    println("""
+
+
+    2. Do the formulations agree?
+    =============================
+
+    Each variant integrated for $NSTEPS steps at min(`DEFAULT_TIMESTEP`, 0.1) with
+    $(nameof(typeof(METHOD))):
+
+      Δy       relative deviation of the final state (q, p) from the reference, ‖Δy‖/‖y‖
+      |ΔH/H|   largest relative energy error along the orbit
+      max|gᵏ|  largest of all three constraints along the orbit, whichever pair the variant retained
+
+    The reference is the compact form in its `:parallel` variant, which is the only one of the six
+    defined for every equilibrium — it depends on no constraint pair and divides by no component of b.
+    """)
+
+    for (name, _, M, icsname) in CASES
+        isdefined(M, icsname) || continue
+        ic = initial(M, icsname)
+
+        results = [(label, regular, regular ? solve(M, ic, makeproblem) : nothing)
+                   for (label, regular, makeproblem) in variants(M, ic)]
+
+        reference = let r = last(results)[3]
+            r === nothing ? nothing : r.y
+        end
+
+        println("  $name")
+        @printf("    %-20s %12s %12s %12s\n", "variant", "Δy", "|ΔH/H|", "max|gᵏ|")
+
+        for (label, regular, r) in results
+            if r === nothing
+                @printf("    %-20s %12s %12s %12s\n", label, regular ? "diverged" : "singular", "-", "-")
+            else
+                Δy = reference === nothing ? NaN : norm(r.y - reference) / norm(reference)
+                @printf("    %-20s %12.3e %12.3e %12.3e\n", label, Δy, r.energy, r.constraints)
+            end
+        end
+        println()
+        flush(stdout)
+    end
+
+    println("""
+    Wherever two variants are both well conditioned they track each other to the accuracy of the
+    nonlinear solve, which is the substantive check on the new formulations: the three pairs
+    parameterise the same constrained system, and the compact form agrees with the Hamilton-Dirac one
+    it was derived from. `TokamakMediumCartesian` is the sharpest case, being the one equilibrium
+    where no component of b vanishes at the initial condition and all three pairs are therefore
+    usable at once.
+
+    Being *usable* and being *well conditioned* are not the same thing, though, and `Dipole3d` is
+    where that shows. All three pairs are regular at its initial condition, but the orbit takes b₁
+    and b₂ through zero, and the two pairs that divide by them hold the constraints only to 1E-3 and
+    the energy to 4E-5 — four orders of magnitude worse than (g¹, g²), which divides by b₃ and holds
+    them to 2E-8 and 2E-9. Nothing is singular there; the multipliers are simply large. Conditioning
+    along the orbit, not merely at the initial condition, is what the choice of pair should follow.""")
+end
+
+
+# ---------------------------------------------------------------------------------------------
+# 3. What does each formulation cost?
+# ---------------------------------------------------------------------------------------------
+
+"""
+    cost(makeproblem, ic)
+
+Per-step cost of one variant and the Newton iteration statistics behind it. A first integration is
+discarded so that compilation does not land in the timing. Returns `nothing` for a variant that
+cannot be integrated.
+"""
+function cost(makeproblem, ic)
+    try
+        problem = makeproblem(ic)
+        nsteps = GeometricIntegrators.GeometricBase.ntime(problem)
+        integrate(problem, METHOD; initialguess = MidpointExtrapolation(5), warn_iterations = 1, OPTIONS...)
+        empty!(ITERLOG.iterations)
+        elapsed = @elapsed integrate(problem, METHOD; initialguess = MidpointExtrapolation(5),
+                                     warn_iterations = 1, OPTIONS...)
+        its = copy(ITERLOG.iterations)
+        return (ms_per_step = elapsed / nsteps * 1E3,
+                mean_iterations = mean(its),
+                peak_iterations = isempty(its) ? 0 : maximum(its))
+    catch
+        return nothing
+    end
+end
+
+function costs()
+    println("""
+
+
+    3. What does each formulation cost?
+    ===================================
+
+    Per-step wall clock and Newton iteration counts, same workload as section 2. Single sample from
+    `@elapsed` after a discarded warm-up run, so treat differences below ~20 % as noise.
+    """)
+
+    @printf("  %-26s %-20s %10s %10s %8s\n",
+            "equilibrium", "variant", "ms/step", "mean its", "peak")
+
+    for (name, _, M, icsname) in CASES
+        isdefined(M, icsname) || continue
+        ic = initial(M, icsname)
+
+        for (label, regular, makeproblem) in variants(M, ic)
+            w = if regular
+                with_logger(ITERLOG) do
+                    cost(makeproblem, ic)
+                end
+            end
+            if w === nothing
+                @printf("  %-26s %-20s %10s %10s %8s\n", name, label,
+                        regular ? "diverged" : "singular", "-", "-")
+            else
+                @printf("  %-26s %-20s %10.3f %10.1f %8d\n",
+                        name, label, w.ms_per_step, w.mean_iterations, w.peak_iterations)
+            end
+        end
+        flush(stdout)
     end
 
     println("""
 
-    Seven of the eleven equilibria have b₁ = 0 *exactly* at their shipped initial condition, so λₒ
-    vanishes and both multipliers are ±Inf or NaN. The model cannot be started there at all: `hodeproblem`
-    fails immediately with a NaN in the Newton direction.
+    Between the three pairs there is nothing to choose on cost — they are the same expressions with
+    permuted indices, and they come out within a few percent of each other everywhere — so the pair
+    should be picked on conditioning alone.
 
-    This is not confined to the curvilinear equilibria. TokamakSmallCartesian fails too — its
-    initial condition sits at y = z = 0, where B_x = 0 — so the deciding factor is where the
-    initial condition is placed relative to the field, not the coordinate system. What the four
-    survivors have in common is simply that their initial condition is off the symmetry plane.
+    Between the formulations there is a great deal to choose. Taking the Hamilton-Dirac form as unity:
 
-    That the survivors are exactly the equilibria the test suite exercises, plus the two toy
-    problems that have their own scripts, is not a coincidence: the remaining 3D test blocks were
-    commented out because of this, and `scripts/guiding_center_3d.jl` displaces its initial
-    condition off the midplane by sqrt(eps()) to work around it.
+      compact, literal    0.86-0.95   it drops the multipliers for a single bracket ratio
+      compact, :parallel  1.21-1.44   the regularised denominator averages all three brackets, so it
+                                      evaluates nine bracket terms where the literal form evaluates three
+      canonicalised       8.9-29.6    ∂λ/∂q and ∂λ/∂p need every second derivative of the field
 
-    Choosing the pair (g¹, g²) instead would put b₃ = b_φ in the denominator, which is the largest
-    component of a tokamak field and does not vanish on the midplane. The choice is currently
-    hard-coded in `guiding_center_3d_equations.jl`, with the alternative commented out beside it;
-    making it selectable would make most of these equilibria usable.""")
+    The order of magnitude on the canonicalised form is the number worth remembering: it buys exact
+    symplecticity rather than approximate, and section 2 shows it giving up two to three orders of
+    magnitude of energy and constraint conservation for it at these step sizes. Its spread is wider
+    than the others because part of the cost is the harder nonlinear solve rather than the right-hand
+    side — Dipole3d, the worst case, is also the only equilibrium whose mean iteration count exceeds
+    one. The regularisation of the compact form costs about half as much again as the literal one,
+    which is a cheap price for never dividing by a component of b.""")
+end
+
+
+function main()
+    conditioning()
+    agreement()
+    costs()
 end
 
 main()

--- a/scripts/study_guiding_center_3d_conditioning.jl
+++ b/scripts/study_guiding_center_3d_conditioning.jl
@@ -10,9 +10,13 @@
 # and show that the Poisson bracket {g₁, g₂} in the denominator of both Lagrange multipliers carries
 # a factor of the b-component belonging to the constraint the pair leaves out:
 #
-#     pair (g³, g¹) → b₁ [B + (p-A)·(∇×b)]     selected by  constraints = :g31
-#     pair (g¹, g²) → b₃ [ ... ]                            constraints = :g12
-#     pair (g², g³) → b₂ [ ... ]                            constraints = :g23
+#     pair (g³, g¹) → +b₁ [B + (p-A)·(∇×b)]    selected by  constraints = :g31
+#     pair (g¹, g²) → +b₃ [ ... ]                           constraints = :g12
+#     pair (g², g³) → -b₂ [ ... ]                           constraints = :g23
+#
+# The minus on the last of those comes from the ordering of that pair rather than from anything
+# physical — reversing a pair flips λₒ and both multipliers together — so only |λₒ| is meaningful in
+# the table below. It is spelled out because λₒ and bₘ then do not always share a sign.
 #
 # The package used to implement only (g³, g¹), so it was singular wherever b₁ = 0. In cylindrical
 # coordinates b₁ = b_R, which vanishes on the midplane of an axisymmetric equilibrium — exactly where
@@ -360,15 +364,18 @@ function costs()
       compact, literal    0.86-0.95   it drops the multipliers for a single bracket ratio
       compact, :parallel  1.21-1.44   the regularised denominator averages all three brackets, so it
                                       evaluates nine bracket terms where the literal form evaluates three
-      canonicalised       8.9-29.6    ∂λ/∂q and ∂λ/∂p need every second derivative of the field
+      canonicalised       8.9-18.8    ∂λ/∂q and ∂λ/∂p need every second derivative of the field
 
     The order of magnitude on the canonicalised form is the number worth remembering: it buys exact
-    symplecticity rather than approximate, and section 2 shows it giving up two to three orders of
-    magnitude of energy and constraint conservation for it at these step sizes. Its spread is wider
-    than the others because part of the cost is the harder nonlinear solve rather than the right-hand
-    side — Dipole3d, the worst case, is also the only equilibrium whose mean iteration count exceeds
-    one. The regularisation of the compact form costs about half as much again as the literal one,
-    which is a cheap price for never dividing by a component of b.""")
+    symplecticity rather than approximate, and section 2 shows it giving up as much as two or three
+    orders of magnitude of energy conservation and four or five of constraint conservation for it at
+    these step sizes. Those are worst cases and not typical ones — on five of the eleven it is within a
+    factor of two on both, and on TokamakSmallCartesian it conserves energy slightly better.
+
+    Its cost spread is wider than the others' because part of the cost is the harder nonlinear solve
+    rather than the right-hand side — Dipole3d, the worst case, is also the only equilibrium whose mean
+    iteration count exceeds one. The regularisation of the compact form costs about half as much again
+    as the literal one, which is a cheap price for never dividing by a component of b.""")
 end
 
 

--- a/scripts/study_invariant_conservation.jl
+++ b/scripts/study_invariant_conservation.jl
@@ -71,7 +71,7 @@ function guiding_centre_3d()
         # the retained pair divided by the component bₘ of b the pair leaves out, so the omitted one
         # drifts 1/bₘ times as much. Reporting the two separately is what makes that visible.
         gs = (c.g₁, c.g₂, c.g₃)
-        retained = map(v -> only(typeof(v).parameters), M.constraint_pair(M.default_constraints()))
+        retained = map(M.unval, M.constraint_pair(M.default_constraints()))
         omitted = only(setdiff(1:3, retained))
 
         @printf("  %-30s %-8s %-14.2e %-14.2e %-14.2e %s\n", name, M.default_constraints(),

--- a/scripts/study_invariant_conservation.jl
+++ b/scripts/study_invariant_conservation.jl
@@ -5,10 +5,11 @@
 # invariants. This tabulates them side by side on the same equilibrium family, which is the check
 # that the diagnostics and the equations of motion agree with each other.
 #
-# For the 3D guiding centre model the interesting quantity is not the energy but the two
+# For the 3D guiding centre model the interesting quantity is not the energy but the three
 # constraints: they vanish along the exact flow, so their magnitude is the drift off the manifold
 # on which the momentum is the guiding centre one-form, and keeping it bounded is the whole point
-# of the approximately symplectic methods of Li, Zhang & Liu.
+# of the approximately symplectic methods of Li, Zhang & Liu. The constraint the retained pair omits
+# is reported separately from the two it keeps, because it drifts 1/bₘ times as much.
 #
 # See docs/src/findings.md, "Conservation across the model families".
 #
@@ -42,10 +43,19 @@ end
 
 function guiding_centre_3d()
     println("\n3D guiding centre — HODEProblem, PartitionedGauss(2)\n")
-    @printf("  %-30s %-14s %-14s %-14s %s\n", "equilibrium", "|ΔH/H|", "|g₁|", "|g₂|", "|Δp_φ/p_φ|")
+    @printf("  %-30s %-8s %-14s %-14s %-14s %s\n",
+            "equilibrium", "pair", "|ΔH/H|", "|gᵏ| retained", "|gᵏ| omitted", "|Δp_φ/p_φ|")
 
-    for (name, M) in (("SolovevIterXpoint",      G3.SolovevIterXpoint),
-                      ("TokamakMediumCartesian", G3.TokamakMediumCartesian))
+    # `SolovevSymmetricField` is the one equilibrium with an initial condition that is left out. Its
+    # pair is well conditioned — `(g², g³)` is the only regular one there, and λₒ ≈ -228 — but it is
+    # the stiffest equilibrium in the package, `‖ϑ‖ ≈ 256`, and the constraint drift grows fast enough
+    # that Newton meets a NaN a few hundred steps into the thousand this section runs. See the note in
+    # its test block in `test/guiding_center_3d_tests.jl`.
+    for (name, M) in (("SolovevIterXpoint",       G3.SolovevIterXpoint),
+                      ("TokamakMediumCartesian",  G3.TokamakMediumCartesian),
+                      ("TokamakSmallCylindrical", G3.TokamakSmallCylindrical),
+                      ("TokamakMediumCylindrical",G3.TokamakMediumCylindrical),
+                      ("TokamakSmallToroidal",    G3.TokamakSmallToroidal))
         prob = M.hodeproblem(M.initial_conditions_barely_passing(); timestep = 0.1, timespan = (0.0, 1E2))
         sol  = integrate(prob, PartitionedGauss(2); initialguess = MidpointExtrapolation(5))
         _, eerr = M.compute_energy_error(sol)
@@ -56,12 +66,24 @@ function guiding_centre_3d()
         else
             "—"
         end
-        @printf("  %-30s %-14.2e %-14.2e %-14.2e %s\n", name, mx(eerr), mx(c.g₁), mx(c.g₂), pstr)
+        # All three components of v × b vanish along the exact flow, but not equally well along a
+        # numerical one: the identity b₁g² - b₂g¹ + b₃g³ = 0 determines the omitted constraint from
+        # the retained pair divided by the component bₘ of b the pair leaves out, so the omitted one
+        # drifts 1/bₘ times as much. Reporting the two separately is what makes that visible.
+        gs = (c.g₁, c.g₂, c.g₃)
+        retained = map(v -> only(typeof(v).parameters), M.constraint_pair(M.default_constraints()))
+        omitted = only(setdiff(1:3, retained))
+
+        @printf("  %-30s %-8s %-14.2e %-14.2e %-14.2e %s\n", name, M.default_constraints(),
+                mx(eerr), maximum(mx(gs[k]) for k in retained), mx(gs[omitted]), pstr)
     end
 
     println("""
-      Only the equilibria that integrate at all are listed. The cylindrical and toroidal ones fail
-      on the singular constraint pair; see study_guiding_center_3d_conditioning.jl.""")
+      Every equilibrium that ships an initial condition integrates now that the constraint pair is
+      selectable; the cylindrical and toroidal ones used to fail on the hard-coded pair. See
+      study_guiding_center_3d_conditioning.jl for the conditioning of each pair, and note that the
+      omitted constraint is the one to watch: it is the retained pair's drift amplified by 1/bₘ, which
+      is why the equilibria with a small bₘ show a worse third column than second.""")
 end
 
 function gyrokinetics()

--- a/src/guiding_center_3d/dipole.jl
+++ b/src/guiding_center_3d/dipole.jl
@@ -27,7 +27,7 @@ The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
 All three pairs are regular at the initial condition, but only this one stays that way. The orbit
 takes `b₁` and `b₂` through zero, so `(g³, g¹)` and `(g², g³)` — which divide by them — hold the
 constraints to 1E-3 and the energy to 4E-5 over a hundred steps, and lose the orbit entirely past a
-few hundred: `|ΔH/H|` reaches 2E3 by `t = 30`, and `hodeproblem_canonical` meets a NaN there.
+few hundred: `|ΔH/H|` reaches 2E3 by `t = 30`, and 7.6E5 under `hodeproblem_canonical`.
 `(g¹, g²)` divides by `b₃`, which does not vanish along this orbit, and holds both to 2E-8 out to
 `t = 300`. This is the one equilibrium in the package where the pair has to be chosen on its
 conditioning along the orbit rather than at the initial condition.

--- a/src/guiding_center_3d/dipole.jl
+++ b/src/guiding_center_3d/dipole.jl
@@ -16,10 +16,23 @@ const DEFAULT_TIMESPAN = (0.0, 90_000.0)
 
 initial_conditions_dipole() = merge(initial_conditions(0.0, [1.0, 2.0, 1.0, 0.01]), (params=(μ=1E-2,),))
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(1E-2),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+All three pairs are regular at the initial condition, but only this one stays that way. The orbit
+takes `b₁` and `b₂` through zero, so `(g³, g¹)` and `(g², g³)` — which divide by them — hold the
+constraints to 1E-3 and the energy to 4E-5 over a hundred steps, and lose the orbit entirely past a
+few hundred: `|ΔH/H|` reaches 2E3 by `t = 30`, and `hodeproblem_canonical` meets a NaN there.
+`(g¹, g²)` divides by `b₃`, which does not vanish along this orbit, and holds both to 2E-8 out to
+`t = 300`. This is the one equilibrium in the package where the pair has to be chosen on its
+conditioning along the orbit rather than at the initial condition.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/guiding_center_3d_canonical.jl
+++ b/src/guiding_center_3d/guiding_center_3d_canonical.jl
@@ -289,12 +289,18 @@ dλ₁dpⱼ(j::Val, t, q, p, params, c) =
     -dλₒdpⱼ(j, t, q, p, c) * λ₁(t, q, p, params, c) / λₒ(t, q, p, c) +
     dbracket_gH_dpⱼ(c[2], j, t, q, p, params) / λₒ(t, q, p, c)
 
+# Both multipliers are a bracket over `λₒ`, so both carry the same `-λ ∂λₒ/λₒ` term regardless of the
+# sign of the numerator: for `λ = N/λₒ`, `∂λ = ∂N/λₒ - λ ∂λₒ/λₒ`. `dλ₂` carried that term with a `+`,
+# which is the sign the quotient rule gives before `-{g₁,H}` is folded back into `λ₂`. The error is
+# proportional to `∂λₒ`, and the whole term is multiplied by a constraint in the right-hand side, so
+# it vanished on the constraint manifold and showed up only as constraint drift — see the
+# finite-difference test in `test/structure_tests.jl`.
 dλ₂dqⱼ(j::Val, t, q, p, params, c) =
-    +dλₒdqⱼ(j, t, q, p, c) * λ₂(t, q, p, params, c) / λₒ(t, q, p, c) -
+    -dλₒdqⱼ(j, t, q, p, c) * λ₂(t, q, p, params, c) / λₒ(t, q, p, c) -
     dbracket_gH_dqⱼ(c[1], j, t, q, p, params) / λₒ(t, q, p, c)
 
 dλ₂dpⱼ(j::Val, t, q, p, params, c) =
-    +dλₒdpⱼ(j, t, q, p, c) * λ₂(t, q, p, params, c) / λₒ(t, q, p, c) -
+    -dλₒdpⱼ(j, t, q, p, c) * λ₂(t, q, p, params, c) / λₒ(t, q, p, c) -
     dbracket_gH_dpⱼ(c[1], j, t, q, p, params) / λₒ(t, q, p, c)
 
 
@@ -355,7 +361,3 @@ end
 
 hodeproblem_canonical(ics::NamedTuple; kwargs...) =
     hodeproblem_canonical(ics.q, ics.p; parameters = ics.params, kwargs...)
-
-
-# The compact form, Eq. (29), which drops the constraint-proportional terms from the right-hand side.
-include("guiding_center_3d_compact.jl")

--- a/src/guiding_center_3d/guiding_center_3d_canonical.jl
+++ b/src/guiding_center_3d/guiding_center_3d_canonical.jl
@@ -1,24 +1,16 @@
+#
+# The canonicalised form of the 3D guiding centre model: `H̃ = H + Σₖ λᵏ gᵏ`, Eq. (13) of Li, Zhang &
+# Liu. Because the multipliers are now differentiated, this needs the second derivatives of both the
+# Hamiltonian and the constraints. The former are written out per index below; the latter come from
+# `guiding_center_3d_constraints.jl` in one indexed definition each.
+#
 
-d²v₁dq₁dq₁(t, q, p) = -d²A₁dx₁dx₁(t, q)
-d²v₁dq₁dq₂(t, q, p) = -d²A₁dx₁dx₂(t, q)
-d²v₁dq₁dq₃(t, q, p) = -d²A₁dx₁dx₃(t, q)
-d²v₁dq₂dq₂(t, q, p) = -d²A₁dx₂dx₂(t, q)
-d²v₁dq₂dq₃(t, q, p) = -d²A₁dx₂dx₃(t, q)
-d²v₁dq₃dq₃(t, q, p) = -d²A₁dx₃dx₃(t, q)
-
-d²v₂dq₁dq₁(t, q, p) = -d²A₂dx₁dx₁(t, q)
-d²v₂dq₁dq₂(t, q, p) = -d²A₂dx₁dx₂(t, q)
-d²v₂dq₁dq₃(t, q, p) = -d²A₂dx₁dx₃(t, q)
-d²v₂dq₂dq₂(t, q, p) = -d²A₂dx₂dx₂(t, q)
-d²v₂dq₂dq₃(t, q, p) = -d²A₂dx₂dx₃(t, q)
-d²v₂dq₃dq₃(t, q, p) = -d²A₂dx₃dx₃(t, q)
-
-d²v₃dq₁dq₁(t, q, p) = -d²A₃dx₁dx₁(t, q)
-d²v₃dq₁dq₂(t, q, p) = -d²A₃dx₁dx₂(t, q)
-d²v₃dq₁dq₃(t, q, p) = -d²A₃dx₁dx₃(t, q)
-d²v₃dq₂dq₂(t, q, p) = -d²A₃dx₂dx₂(t, q)
-d²v₃dq₂dq₃(t, q, p) = -d²A₃dx₂dx₃(t, q)
-d²v₃dq₃dq₃(t, q, p) = -d²A₃dx₃dx₃(t, q)
+# The named second derivatives of `v`, kept for the Hamiltonian block below, as aliases of the
+# generic accessor. Only the upper triangle exists — `∂²v/∂qⱼ∂qₖ` is symmetric.
+for i in 1:3, j in 1:3, k in j:3
+    @eval $(Symbol("d²v", INDEX_SUBSCRIPTS[i], "dq", INDEX_SUBSCRIPTS[j], "dq", INDEX_SUBSCRIPTS[k]))(t, q, p) =
+        d²vᵢdqⱼdqₖ($(Val(i)), $(Val(j)), $(Val(k)), t, q, p)
+end
 
 
 d²Hdq₁dq₁(t, q, p, params) = (
@@ -250,444 +242,81 @@ d²Hdp₃dp₃(t, q, p, params) = (
 )
 
 
-d²g₁dq₁dq₁(t, q, p) = (d²b₁dx₁dx₁(t, q) * v₂(t, q, p) + db₁dx₁(t, q) * dv₂dq₁(t, q, p)) -
-                      (d²b₂dx₁dx₁(t, q) * v₁(t, q, p) + db₂dx₁(t, q) * dv₁dq₁(t, q, p)) +
-                      (db₁dx₁(t, q) * dv₂dq₁(t, q, p) + b₁(t, q) * d²v₂dq₁dq₁(t, q, p)) -
-                      (db₂dx₁(t, q) * dv₁dq₁(t, q, p) + b₂(t, q) * d²v₁dq₁dq₁(t, q, p))
-
-d²g₁dq₁dq₂(t, q, p) = (d²b₁dx₁dx₂(t, q) * v₂(t, q, p) + db₁dx₂(t, q) * dv₂dq₁(t, q, p)) -
-                      (d²b₂dx₁dx₂(t, q) * v₁(t, q, p) + db₂dx₂(t, q) * dv₁dq₁(t, q, p)) +
-                      (db₁dx₁(t, q) * dv₂dq₂(t, q, p) + b₁(t, q) * d²v₂dq₁dq₂(t, q, p)) -
-                      (db₂dx₁(t, q) * dv₁dq₂(t, q, p) + b₂(t, q) * d²v₁dq₁dq₂(t, q, p))
-
-d²g₁dq₁dq₃(t, q, p) = (d²b₁dx₁dx₃(t, q) * v₂(t, q, p) + db₁dx₃(t, q) * dv₂dq₁(t, q, p)) -
-                      (d²b₂dx₁dx₃(t, q) * v₁(t, q, p) + db₂dx₃(t, q) * dv₁dq₁(t, q, p)) +
-                      (db₁dx₁(t, q) * dv₂dq₃(t, q, p) + b₁(t, q) * d²v₂dq₁dq₃(t, q, p)) -
-                      (db₂dx₁(t, q) * dv₁dq₃(t, q, p) + b₂(t, q) * d²v₁dq₁dq₃(t, q, p))
-
-d²g₁dq₂dq₁(t, q, p) = (d²b₁dx₂dx₁(t, q) * v₂(t, q, p) + db₁dx₁(t, q) * dv₂dq₂(t, q, p)) -
-                      (d²b₂dx₂dx₁(t, q) * v₁(t, q, p) + db₂dx₁(t, q) * dv₁dq₂(t, q, p)) +
-                      (db₁dx₂(t, q) * dv₂dq₁(t, q, p) + b₁(t, q) * d²v₂dq₁dq₂(t, q, p)) -
-                      (db₂dx₂(t, q) * dv₁dq₁(t, q, p) + b₂(t, q) * d²v₁dq₁dq₂(t, q, p))
-
-d²g₁dq₂dq₂(t, q, p) = (d²b₁dx₂dx₂(t, q) * v₂(t, q, p) + db₁dx₂(t, q) * dv₂dq₂(t, q, p)) -
-                      (d²b₂dx₂dx₂(t, q) * v₁(t, q, p) + db₂dx₂(t, q) * dv₁dq₂(t, q, p)) +
-                      (db₁dx₂(t, q) * dv₂dq₂(t, q, p) + b₁(t, q) * d²v₂dq₂dq₂(t, q, p)) -
-                      (db₂dx₂(t, q) * dv₁dq₂(t, q, p) + b₂(t, q) * d²v₁dq₂dq₂(t, q, p))
-
-d²g₁dq₂dq₃(t, q, p) = (d²b₁dx₂dx₃(t, q) * v₂(t, q, p) + db₁dx₃(t, q) * dv₂dq₂(t, q, p)) -
-                      (d²b₂dx₂dx₃(t, q) * v₁(t, q, p) + db₂dx₃(t, q) * dv₁dq₂(t, q, p)) +
-                      (db₁dx₂(t, q) * dv₂dq₃(t, q, p) + b₁(t, q) * d²v₂dq₂dq₃(t, q, p)) -
-                      (db₂dx₂(t, q) * dv₁dq₃(t, q, p) + b₂(t, q) * d²v₁dq₂dq₃(t, q, p))
-
-d²g₁dq₃dq₁(t, q, p) = (d²b₁dx₃dx₁(t, q) * v₂(t, q, p) + db₁dx₁(t, q) * dv₂dq₃(t, q, p)) -
-                      (d²b₂dx₃dx₁(t, q) * v₁(t, q, p) + db₂dx₁(t, q) * dv₁dq₃(t, q, p)) +
-                      (db₁dx₃(t, q) * dv₂dq₁(t, q, p) + b₁(t, q) * d²v₂dq₁dq₃(t, q, p)) -
-                      (db₂dx₃(t, q) * dv₁dq₁(t, q, p) + b₂(t, q) * d²v₁dq₁dq₃(t, q, p))
-
-d²g₁dq₃dq₂(t, q, p) = (d²b₁dx₃dx₂(t, q) * v₂(t, q, p) + db₁dx₂(t, q) * dv₂dq₃(t, q, p)) -
-                      (d²b₂dx₃dx₂(t, q) * v₁(t, q, p) + db₂dx₂(t, q) * dv₁dq₃(t, q, p)) +
-                      (db₁dx₃(t, q) * dv₂dq₂(t, q, p) + b₁(t, q) * d²v₂dq₂dq₃(t, q, p)) -
-                      (db₂dx₃(t, q) * dv₁dq₂(t, q, p) + b₂(t, q) * d²v₁dq₂dq₃(t, q, p))
-
-d²g₁dq₃dq₃(t, q, p) = (d²b₁dx₃dx₃(t, q) * v₂(t, q, p) + db₁dx₃(t, q) * dv₂dq₃(t, q, p)) -
-                      (d²b₂dx₃dx₃(t, q) * v₁(t, q, p) + db₂dx₃(t, q) * dv₁dq₃(t, q, p)) +
-                      (db₁dx₃(t, q) * dv₂dq₃(t, q, p) + b₁(t, q) * d²v₂dq₃dq₃(t, q, p)) -
-                      (db₂dx₃(t, q) * dv₁dq₃(t, q, p) + b₂(t, q) * d²v₁dq₃dq₃(t, q, p))
+# Indexed views of the Hessian blocks above. Only the upper triangle of the `qq` and `pp` blocks is
+# written out, so those two symmetrise here; the `qp` block is not symmetric and has all nine.
+for i in 1:3, j in 1:3
+    @eval @inline d²Hdqᵢdqⱼ(::Val{$i}, ::Val{$j}, t, q, p, params) =
+        $(Symbol("d²Hdq", INDEX_SUBSCRIPTS[min(i, j)], "dq", INDEX_SUBSCRIPTS[max(i, j)]))(t, q, p, params)
+    @eval @inline d²Hdpᵢdpⱼ(::Val{$i}, ::Val{$j}, t, q, p, params) =
+        $(Symbol("d²Hdp", INDEX_SUBSCRIPTS[min(i, j)], "dp", INDEX_SUBSCRIPTS[max(i, j)]))(t, q, p, params)
+    @eval @inline d²Hdqᵢdpⱼ(::Val{$i}, ::Val{$j}, t, q, p, params) =
+        $(Symbol("d²Hdq", INDEX_SUBSCRIPTS[i], "dp", INDEX_SUBSCRIPTS[j]))(t, q, p, params)
+end
 
 
-d²g₂dq₁dq₁(t, q, p) = (d²b₁dx₁dx₁(t, q) * v₃(t, q, p) + db₁dx₁(t, q) * dv₃dq₁(t, q, p)) -
-                      (d²b₃dx₁dx₁(t, q) * v₁(t, q, p) + db₃dx₁(t, q) * dv₁dq₁(t, q, p)) +
-                      (db₁dx₁(t, q) * dv₃dq₁(t, q, p) + b₁(t, q) * d²v₃dq₁dq₁(t, q, p)) -
-                      (db₃dx₁(t, q) * dv₁dq₁(t, q, p) + b₃(t, q) * d²v₁dq₁dq₁(t, q, p))
+# Derivatives of the two brackets of `guiding_center_3d_equations.jl`. The `∂²gᵏ/∂pₗ∂pₘ` terms that
+# the product rule would contribute vanish identically and are left out.
+@inline dbracket_gg_dqⱼ(k₁::Val, k₂::Val, j::Val, t, q, p) = contract(l ->
+    d²gᵏdqₗdqₘ(k₁, j, l, t, q, p) * dgᵏdpₗ(k₂, l, t, q, p) +
+    dgᵏdqₗ(k₁, l, t, q, p) * d²gᵏdqₗdpₘ(k₂, j, l, t, q, p) -
+    d²gᵏdqₗdpₘ(k₁, j, l, t, q, p) * dgᵏdqₗ(k₂, l, t, q, p) -
+    dgᵏdpₗ(k₁, l, t, q, p) * d²gᵏdqₗdqₘ(k₂, j, l, t, q, p))
 
-d²g₂dq₁dq₂(t, q, p) = (d²b₁dx₁dx₂(t, q) * v₃(t, q, p) + db₁dx₂(t, q) * dv₃dq₁(t, q, p)) -
-                      (d²b₃dx₁dx₂(t, q) * v₁(t, q, p) + db₃dx₂(t, q) * dv₁dq₁(t, q, p)) +
-                      (db₁dx₁(t, q) * dv₃dq₂(t, q, p) + b₁(t, q) * d²v₃dq₁dq₂(t, q, p)) -
-                      (db₃dx₁(t, q) * dv₁dq₂(t, q, p) + b₃(t, q) * d²v₁dq₁dq₂(t, q, p))
+@inline dbracket_gg_dpⱼ(k₁::Val, k₂::Val, j::Val, t, q, p) = contract(l ->
+    d²gᵏdqₗdpₘ(k₁, l, j, t, q, p) * dgᵏdpₗ(k₂, l, t, q, p) -
+    dgᵏdpₗ(k₁, l, t, q, p) * d²gᵏdqₗdpₘ(k₂, l, j, t, q, p))
 
-d²g₂dq₁dq₃(t, q, p) = (d²b₁dx₁dx₃(t, q) * v₃(t, q, p) + db₁dx₃(t, q) * dv₃dq₁(t, q, p)) -
-                      (d²b₃dx₁dx₃(t, q) * v₁(t, q, p) + db₃dx₃(t, q) * dv₁dq₁(t, q, p)) +
-                      (db₁dx₁(t, q) * dv₃dq₃(t, q, p) + b₁(t, q) * d²v₃dq₁dq₃(t, q, p)) -
-                      (db₃dx₁(t, q) * dv₁dq₃(t, q, p) + b₃(t, q) * d²v₁dq₁dq₃(t, q, p))
+@inline dbracket_gH_dqⱼ(k::Val, j::Val, t, q, p, params) = contract(l ->
+    d²gᵏdqₗdqₘ(k, j, l, t, q, p) * dHdpᵢ(l, t, q, p, params) +
+    dgᵏdqₗ(k, l, t, q, p) * d²Hdqᵢdpⱼ(j, l, t, q, p, params) -
+    d²gᵏdqₗdpₘ(k, j, l, t, q, p) * dHdqᵢ(l, t, q, p, params) -
+    dgᵏdpₗ(k, l, t, q, p) * d²Hdqᵢdqⱼ(j, l, t, q, p, params))
 
-d²g₂dq₂dq₁(t, q, p) = (d²b₁dx₂dx₁(t, q) * v₃(t, q, p) + db₁dx₁(t, q) * dv₃dq₂(t, q, p)) -
-                      (d²b₃dx₂dx₁(t, q) * v₁(t, q, p) + db₃dx₁(t, q) * dv₁dq₂(t, q, p)) +
-                      (db₁dx₂(t, q) * dv₃dq₁(t, q, p) + b₁(t, q) * d²v₃dq₁dq₂(t, q, p)) -
-                      (db₃dx₂(t, q) * dv₁dq₁(t, q, p) + b₃(t, q) * d²v₁dq₁dq₂(t, q, p))
-
-d²g₂dq₂dq₂(t, q, p) = (d²b₁dx₂dx₂(t, q) * v₃(t, q, p) + db₁dx₂(t, q) * dv₃dq₂(t, q, p)) -
-                      (d²b₃dx₂dx₂(t, q) * v₁(t, q, p) + db₃dx₂(t, q) * dv₁dq₂(t, q, p)) +
-                      (db₁dx₂(t, q) * dv₃dq₂(t, q, p) + b₁(t, q) * d²v₃dq₂dq₂(t, q, p)) -
-                      (db₃dx₂(t, q) * dv₁dq₂(t, q, p) + b₃(t, q) * d²v₁dq₂dq₂(t, q, p))
-
-d²g₂dq₂dq₃(t, q, p) = (d²b₁dx₂dx₃(t, q) * v₃(t, q, p) + db₁dx₃(t, q) * dv₃dq₂(t, q, p)) -
-                      (d²b₃dx₂dx₃(t, q) * v₁(t, q, p) + db₃dx₃(t, q) * dv₁dq₂(t, q, p)) +
-                      (db₁dx₂(t, q) * dv₃dq₃(t, q, p) + b₁(t, q) * d²v₃dq₂dq₃(t, q, p)) -
-                      (db₃dx₂(t, q) * dv₁dq₃(t, q, p) + b₃(t, q) * d²v₁dq₂dq₃(t, q, p))
-
-d²g₂dq₃dq₁(t, q, p) = (d²b₁dx₃dx₁(t, q) * v₃(t, q, p) + db₁dx₁(t, q) * dv₃dq₃(t, q, p)) -
-                      (d²b₃dx₃dx₁(t, q) * v₁(t, q, p) + db₃dx₁(t, q) * dv₁dq₃(t, q, p)) +
-                      (db₁dx₃(t, q) * dv₃dq₁(t, q, p) + b₁(t, q) * d²v₃dq₁dq₃(t, q, p)) -
-                      (db₃dx₃(t, q) * dv₁dq₁(t, q, p) + b₃(t, q) * d²v₁dq₁dq₃(t, q, p))
-
-d²g₂dq₃dq₂(t, q, p) = (d²b₁dx₃dx₂(t, q) * v₃(t, q, p) + db₁dx₂(t, q) * dv₃dq₃(t, q, p)) -
-                      (d²b₃dx₃dx₂(t, q) * v₁(t, q, p) + db₃dx₂(t, q) * dv₁dq₃(t, q, p)) +
-                      (db₁dx₃(t, q) * dv₃dq₂(t, q, p) + b₁(t, q) * d²v₃dq₂dq₃(t, q, p)) -
-                      (db₃dx₃(t, q) * dv₁dq₂(t, q, p) + b₃(t, q) * d²v₁dq₂dq₃(t, q, p))
-
-d²g₂dq₃dq₃(t, q, p) = (d²b₁dx₃dx₃(t, q) * v₃(t, q, p) + db₁dx₃(t, q) * dv₃dq₃(t, q, p)) -
-                      (d²b₃dx₃dx₃(t, q) * v₁(t, q, p) + db₃dx₃(t, q) * dv₁dq₃(t, q, p)) +
-                      (db₁dx₃(t, q) * dv₃dq₃(t, q, p) + b₁(t, q) * d²v₃dq₃dq₃(t, q, p)) -
-                      (db₃dx₃(t, q) * dv₁dq₃(t, q, p) + b₃(t, q) * d²v₁dq₃dq₃(t, q, p))
+@inline dbracket_gH_dpⱼ(k::Val, j::Val, t, q, p, params) = contract(l ->
+    d²gᵏdqₗdpₘ(k, l, j, t, q, p) * dHdpᵢ(l, t, q, p, params) +
+    dgᵏdqₗ(k, l, t, q, p) * d²Hdpᵢdpⱼ(j, l, t, q, p, params) -
+    dgᵏdpₗ(k, l, t, q, p) * d²Hdqᵢdpⱼ(l, j, t, q, p, params))
 
 
-d²g₁dq₁dp₁(t, q, p) = db₁dx₁(t, q) * dv₂dp₁(t, q, p) - db₂dx₁(t, q) * dv₁dp₁(t, q, p)
-d²g₁dq₁dp₂(t, q, p) = db₁dx₁(t, q) * dv₂dp₂(t, q, p) - db₂dx₁(t, q) * dv₁dp₂(t, q, p)
-d²g₁dq₁dp₃(t, q, p) = db₁dx₁(t, q) * dv₂dp₃(t, q, p) - db₂dx₁(t, q) * dv₁dp₃(t, q, p)
+dλₒdqⱼ(j::Val, t, q, p, c) = dbracket_gg_dqⱼ(c[1], c[2], j, t, q, p)
+dλₒdpⱼ(j::Val, t, q, p, c) = dbracket_gg_dpⱼ(c[1], c[2], j, t, q, p)
 
-d²g₁dq₂dp₁(t, q, p) = db₁dx₂(t, q) * dv₂dp₁(t, q, p) - db₂dx₂(t, q) * dv₁dp₁(t, q, p)
-d²g₁dq₂dp₂(t, q, p) = db₁dx₂(t, q) * dv₂dp₂(t, q, p) - db₂dx₂(t, q) * dv₁dp₂(t, q, p)
-d²g₁dq₂dp₃(t, q, p) = db₁dx₂(t, q) * dv₂dp₃(t, q, p) - db₂dx₂(t, q) * dv₁dp₃(t, q, p)
+dλ₁dqⱼ(j::Val, t, q, p, params, c) =
+    -dλₒdqⱼ(j, t, q, p, c) * λ₁(t, q, p, params, c) / λₒ(t, q, p, c) +
+    dbracket_gH_dqⱼ(c[2], j, t, q, p, params) / λₒ(t, q, p, c)
 
-d²g₁dq₃dp₁(t, q, p) = db₁dx₃(t, q) * dv₂dp₁(t, q, p) - db₂dx₃(t, q) * dv₁dp₁(t, q, p)
-d²g₁dq₃dp₂(t, q, p) = db₁dx₃(t, q) * dv₂dp₂(t, q, p) - db₂dx₃(t, q) * dv₁dp₂(t, q, p)
-d²g₁dq₃dp₃(t, q, p) = db₁dx₃(t, q) * dv₂dp₃(t, q, p) - db₂dx₃(t, q) * dv₁dp₃(t, q, p)
+dλ₁dpⱼ(j::Val, t, q, p, params, c) =
+    -dλₒdpⱼ(j, t, q, p, c) * λ₁(t, q, p, params, c) / λₒ(t, q, p, c) +
+    dbracket_gH_dpⱼ(c[2], j, t, q, p, params) / λₒ(t, q, p, c)
 
+dλ₂dqⱼ(j::Val, t, q, p, params, c) =
+    +dλₒdqⱼ(j, t, q, p, c) * λ₂(t, q, p, params, c) / λₒ(t, q, p, c) -
+    dbracket_gH_dqⱼ(c[1], j, t, q, p, params) / λₒ(t, q, p, c)
 
-d²g₂dq₁dp₁(t, q, p) = db₁dx₁(t, q) * dv₃dp₁(t, q, p) - db₃dx₁(t, q) * dv₁dp₁(t, q, p)
-d²g₂dq₁dp₂(t, q, p) = db₁dx₁(t, q) * dv₃dp₂(t, q, p) - db₃dx₁(t, q) * dv₁dp₂(t, q, p)
-d²g₂dq₁dp₃(t, q, p) = db₁dx₁(t, q) * dv₃dp₃(t, q, p) - db₃dx₁(t, q) * dv₁dp₃(t, q, p)
-
-d²g₂dq₂dp₁(t, q, p) = db₁dx₂(t, q) * dv₃dp₁(t, q, p) - db₃dx₂(t, q) * dv₁dp₁(t, q, p)
-d²g₂dq₂dp₂(t, q, p) = db₁dx₂(t, q) * dv₃dp₂(t, q, p) - db₃dx₂(t, q) * dv₁dp₂(t, q, p)
-d²g₂dq₂dp₃(t, q, p) = db₁dx₂(t, q) * dv₃dp₃(t, q, p) - db₃dx₂(t, q) * dv₁dp₃(t, q, p)
-
-d²g₂dq₃dp₁(t, q, p) = db₁dx₃(t, q) * dv₃dp₁(t, q, p) - db₃dx₃(t, q) * dv₁dp₁(t, q, p)
-d²g₂dq₃dp₂(t, q, p) = db₁dx₃(t, q) * dv₃dp₂(t, q, p) - db₃dx₃(t, q) * dv₁dp₂(t, q, p)
-d²g₂dq₃dp₃(t, q, p) = db₁dx₃(t, q) * dv₃dp₃(t, q, p) - db₃dx₃(t, q) * dv₁dp₃(t, q, p)
+dλ₂dpⱼ(j::Val, t, q, p, params, c) =
+    +dλₒdpⱼ(j, t, q, p, c) * λ₂(t, q, p, params, c) / λₒ(t, q, p, c) -
+    dbracket_gH_dpⱼ(c[1], j, t, q, p, params) / λₒ(t, q, p, c)
 
 
-d²g₁dp₁dp₁(t, q, p) = zero(eltype(q))
-d²g₁dp₁dp₂(t, q, p) = zero(eltype(q))
-d²g₁dp₁dp₃(t, q, p) = zero(eltype(q))
+function guiding_center_3d_canonical_v(v, t, q, p, params, c = default_constraint_pair())
+    guiding_center_3d_v(v, t, q, p, params, c)
 
-d²g₁dp₂dp₁(t, q, p) = zero(eltype(q))
-d²g₁dp₂dp₂(t, q, p) = zero(eltype(q))
-d²g₁dp₂dp₃(t, q, p) = zero(eltype(q))
+    g1 = gᵏ(c[1], t, q, p)
+    g2 = gᵏ(c[2], t, q, p)
 
-d²g₁dp₃dp₁(t, q, p) = zero(eltype(q))
-d²g₁dp₃dp₂(t, q, p) = zero(eltype(q))
-d²g₁dp₃dp₃(t, q, p) = zero(eltype(q))
-
-
-d²g₂dp₁dp₁(t, q, p) = zero(eltype(q))
-d²g₂dp₁dp₂(t, q, p) = zero(eltype(q))
-d²g₂dp₁dp₃(t, q, p) = zero(eltype(q))
-
-d²g₂dp₂dp₁(t, q, p) = zero(eltype(q))
-d²g₂dp₂dp₂(t, q, p) = zero(eltype(q))
-d²g₂dp₂dp₃(t, q, p) = zero(eltype(q))
-
-d²g₂dp₃dp₁(t, q, p) = zero(eltype(q))
-d²g₂dp₃dp₂(t, q, p) = zero(eltype(q))
-d²g₂dp₃dp₃(t, q, p) = zero(eltype(q))
-
-
-dλₒdq₁(t, q, p) = (
-    d²g₁dq₁dq₁(t, q, p) * dg₂dp₁(t, q, p) +
-    d²g₁dq₁dq₂(t, q, p) * dg₂dp₂(t, q, p) +
-    d²g₁dq₁dq₃(t, q, p) * dg₂dp₃(t, q, p) -
-    d²g₁dq₁dp₁(t, q, p) * dg₂dq₁(t, q, p) -
-    d²g₁dq₁dp₂(t, q, p) * dg₂dq₂(t, q, p) -
-    d²g₁dq₁dp₃(t, q, p) * dg₂dq₃(t, q, p) +
-    dg₁dq₁(t, q, p) * d²g₂dq₁dp₁(t, q, p) +
-    dg₁dq₂(t, q, p) * d²g₂dq₁dp₂(t, q, p) +
-    dg₁dq₃(t, q, p) * d²g₂dq₁dp₃(t, q, p) -
-    dg₁dp₁(t, q, p) * d²g₂dq₁dq₁(t, q, p) -
-    dg₁dp₂(t, q, p) * d²g₂dq₁dq₂(t, q, p) -
-    dg₁dp₃(t, q, p) * d²g₂dq₁dq₃(t, q, p)
-)
-
-dλₒdq₂(t, q, p) = (
-    d²g₁dq₂dq₁(t, q, p) * dg₂dp₁(t, q, p) +
-    d²g₁dq₂dq₂(t, q, p) * dg₂dp₂(t, q, p) +
-    d²g₁dq₂dq₃(t, q, p) * dg₂dp₃(t, q, p) -
-    d²g₁dq₂dp₁(t, q, p) * dg₂dq₁(t, q, p) -
-    d²g₁dq₂dp₂(t, q, p) * dg₂dq₂(t, q, p) -
-    d²g₁dq₂dp₃(t, q, p) * dg₂dq₃(t, q, p) +
-    dg₁dq₁(t, q, p) * d²g₂dq₂dp₁(t, q, p) +
-    dg₁dq₂(t, q, p) * d²g₂dq₂dp₂(t, q, p) +
-    dg₁dq₃(t, q, p) * d²g₂dq₂dp₃(t, q, p) -
-    dg₁dp₁(t, q, p) * d²g₂dq₁dq₂(t, q, p) -
-    dg₁dp₂(t, q, p) * d²g₂dq₂dq₂(t, q, p) -
-    dg₁dp₃(t, q, p) * d²g₂dq₃dq₂(t, q, p)
-)
-
-dλₒdq₃(t, q, p) = (
-    d²g₁dq₃dq₁(t, q, p) * dg₂dp₁(t, q, p) +
-    d²g₁dq₃dq₂(t, q, p) * dg₂dp₂(t, q, p) +
-    d²g₁dq₃dq₃(t, q, p) * dg₂dp₃(t, q, p) -
-    d²g₁dq₃dp₁(t, q, p) * dg₂dq₁(t, q, p) -
-    d²g₁dq₃dp₂(t, q, p) * dg₂dq₂(t, q, p) -
-    d²g₁dq₃dp₃(t, q, p) * dg₂dq₃(t, q, p) +
-    dg₁dq₁(t, q, p) * d²g₂dq₃dp₁(t, q, p) +
-    dg₁dq₂(t, q, p) * d²g₂dq₃dp₂(t, q, p) +
-    dg₁dq₃(t, q, p) * d²g₂dq₃dp₃(t, q, p) -
-    dg₁dp₁(t, q, p) * d²g₂dq₃dq₁(t, q, p) -
-    dg₁dp₂(t, q, p) * d²g₂dq₃dq₂(t, q, p) -
-    dg₁dp₃(t, q, p) * d²g₂dq₃dq₃(t, q, p)
-)
-
-dλₒdp₁(t, q, p) = (
-    d²g₁dq₁dp₁(t, q, p) * dg₂dp₁(t, q, p) +
-    d²g₁dq₂dp₁(t, q, p) * dg₂dp₂(t, q, p) +
-    d²g₁dq₃dp₁(t, q, p) * dg₂dp₃(t, q, p) -
-    d²g₁dp₁dp₁(t, q, p) * dg₂dq₁(t, q, p) -
-    d²g₁dp₁dp₂(t, q, p) * dg₂dq₂(t, q, p) -
-    d²g₁dp₁dp₃(t, q, p) * dg₂dq₃(t, q, p) +
-    dg₁dq₁(t, q, p) * d²g₂dp₁dp₁(t, q, p) +
-    dg₁dq₂(t, q, p) * d²g₂dp₂dp₁(t, q, p) +
-    dg₁dq₃(t, q, p) * d²g₂dp₃dp₁(t, q, p) -
-    dg₁dp₁(t, q, p) * d²g₂dq₁dp₁(t, q, p) -
-    dg₁dp₂(t, q, p) * d²g₂dq₂dp₁(t, q, p) -
-    dg₁dp₃(t, q, p) * d²g₂dq₃dp₁(t, q, p)
-)
-
-dλₒdp₂(t, q, p) = (
-    d²g₁dq₁dp₂(t, q, p) * dg₂dp₁(t, q, p) +
-    d²g₁dq₂dp₂(t, q, p) * dg₂dp₂(t, q, p) +
-    d²g₁dq₃dp₂(t, q, p) * dg₂dp₃(t, q, p) -
-    d²g₁dp₁dp₂(t, q, p) * dg₂dq₁(t, q, p) -
-    d²g₁dp₂dp₂(t, q, p) * dg₂dq₂(t, q, p) -
-    d²g₁dp₃dp₂(t, q, p) * dg₂dq₃(t, q, p) +
-    dg₁dq₁(t, q, p) * d²g₂dp₁dp₂(t, q, p) +
-    dg₁dq₂(t, q, p) * d²g₂dp₂dp₂(t, q, p) +
-    dg₁dq₃(t, q, p) * d²g₂dp₃dp₂(t, q, p) -
-    dg₁dp₁(t, q, p) * d²g₂dq₁dp₂(t, q, p) -
-    dg₁dp₂(t, q, p) * d²g₂dq₂dp₂(t, q, p) -
-    dg₁dp₃(t, q, p) * d²g₂dq₃dp₂(t, q, p)
-)
-
-dλₒdp₃(t, q, p) = (
-    d²g₁dq₁dp₃(t, q, p) * dg₂dp₁(t, q, p) +
-    d²g₁dq₂dp₃(t, q, p) * dg₂dp₂(t, q, p) +
-    d²g₁dq₃dp₃(t, q, p) * dg₂dp₃(t, q, p) -
-    d²g₁dp₁dp₃(t, q, p) * dg₂dq₁(t, q, p) -
-    d²g₁dp₂dp₃(t, q, p) * dg₂dq₂(t, q, p) -
-    d²g₁dp₃dp₃(t, q, p) * dg₂dq₃(t, q, p) +
-    dg₁dq₁(t, q, p) * d²g₂dp₁dp₃(t, q, p) +
-    dg₁dq₂(t, q, p) * d²g₂dp₂dp₃(t, q, p) +
-    dg₁dq₃(t, q, p) * d²g₂dp₃dp₃(t, q, p) -
-    dg₁dp₁(t, q, p) * d²g₂dq₁dp₃(t, q, p) -
-    dg₁dp₂(t, q, p) * d²g₂dq₂dp₃(t, q, p) -
-    dg₁dp₃(t, q, p) * d²g₂dq₃dp₃(t, q, p)
-)
-
-dλ₁dq₁(t, q, p, params) = -dλₒdq₁(t, q, p) * λ₁(t, q, p, params) / λₒ(t, q, p) + (
-    d²g₂dq₁dq₁(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₂dq₁dq₂(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₂dq₁dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₂dq₁dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₂dq₁dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₂dq₁dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₂dq₁(t, q, p) * d²Hdq₁dp₁(t, q, p, params) +
-    dg₂dq₂(t, q, p) * d²Hdq₁dp₂(t, q, p, params) +
-    dg₂dq₃(t, q, p) * d²Hdq₁dp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * d²Hdq₁dq₁(t, q, p, params) -
-    dg₂dp₂(t, q, p) * d²Hdq₁dq₂(t, q, p, params) -
-    dg₂dp₃(t, q, p) * d²Hdq₁dq₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₁dq₂(t, q, p, params) = -dλₒdq₂(t, q, p) * λ₁(t, q, p, params) / λₒ(t, q, p) + (
-    d²g₂dq₁dq₂(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₂dq₂dq₂(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₂dq₂dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₂dq₂dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₂dq₂dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₂dq₂dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₂dq₁(t, q, p) * d²Hdq₂dp₁(t, q, p, params) +
-    dg₂dq₂(t, q, p) * d²Hdq₂dp₂(t, q, p, params) +
-    dg₂dq₃(t, q, p) * d²Hdq₂dp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * d²Hdq₁dq₂(t, q, p, params) -
-    dg₂dp₂(t, q, p) * d²Hdq₂dq₂(t, q, p, params) -
-    dg₂dp₃(t, q, p) * d²Hdq₂dq₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₁dq₃(t, q, p, params) = -dλₒdq₃(t, q, p) * λ₁(t, q, p, params) / λₒ(t, q, p) + (
-    d²g₂dq₁dq₃(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₂dq₂dq₃(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₂dq₃dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₂dq₃dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₂dq₃dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₂dq₃dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₂dq₁(t, q, p) * d²Hdq₃dp₁(t, q, p, params) +
-    dg₂dq₂(t, q, p) * d²Hdq₃dp₂(t, q, p, params) +
-    dg₂dq₃(t, q, p) * d²Hdq₃dp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * d²Hdq₁dq₃(t, q, p, params) -
-    dg₂dp₂(t, q, p) * d²Hdq₂dq₃(t, q, p, params) -
-    dg₂dp₃(t, q, p) * d²Hdq₃dq₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₁dp₁(t, q, p, params) = -dλₒdp₁(t, q, p) * λ₁(t, q, p, params) / λₒ(t, q, p) + (
-    d²g₂dq₁dp₁(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₂dq₂dp₁(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₂dq₃dp₁(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₂dp₁dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₂dp₁dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₂dp₁dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₂dq₁(t, q, p) * d²Hdp₁dp₁(t, q, p, params) +
-    dg₂dq₂(t, q, p) * d²Hdp₁dp₂(t, q, p, params) +
-    dg₂dq₃(t, q, p) * d²Hdp₁dp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * d²Hdq₁dp₁(t, q, p, params) -
-    dg₂dp₂(t, q, p) * d²Hdq₂dp₁(t, q, p, params) -
-    dg₂dp₃(t, q, p) * d²Hdq₃dp₁(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₁dp₂(t, q, p, params) = -dλₒdp₂(t, q, p) * λ₁(t, q, p, params) / λₒ(t, q, p) + (
-    d²g₂dq₁dp₂(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₂dq₂dp₂(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₂dq₃dp₂(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₂dp₁dp₂(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₂dp₂dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₂dp₂dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₂dq₁(t, q, p) * d²Hdp₁dp₂(t, q, p, params) +
-    dg₂dq₂(t, q, p) * d²Hdp₂dp₂(t, q, p, params) +
-    dg₂dq₃(t, q, p) * d²Hdp₂dp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * d²Hdq₁dp₂(t, q, p, params) -
-    dg₂dp₂(t, q, p) * d²Hdq₂dp₂(t, q, p, params) -
-    dg₂dp₃(t, q, p) * d²Hdq₃dp₂(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₁dp₃(t, q, p, params) = -dλₒdp₃(t, q, p) * λ₁(t, q, p, params) / λₒ(t, q, p) + (
-    d²g₂dq₁dp₃(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₂dq₂dp₃(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₂dq₃dp₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₂dp₁dp₃(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₂dp₂dp₃(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₂dp₃dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₂dq₁(t, q, p) * d²Hdp₁dp₃(t, q, p, params) +
-    dg₂dq₂(t, q, p) * d²Hdp₂dp₃(t, q, p, params) +
-    dg₂dq₃(t, q, p) * d²Hdp₃dp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * d²Hdq₁dp₃(t, q, p, params) -
-    dg₂dp₂(t, q, p) * d²Hdq₂dp₃(t, q, p, params) -
-    dg₂dp₃(t, q, p) * d²Hdq₃dp₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₂dq₁(t, q, p, params) = +dλₒdq₁(t, q, p) * λ₂(t, q, p, params) / λₒ(t, q, p) - (
-    d²g₁dq₁dq₁(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₁dq₁dq₂(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₁dq₁dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₁dq₁dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₁dq₁dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₁dq₁dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₁dq₁(t, q, p) * d²Hdq₁dp₁(t, q, p, params) +
-    dg₁dq₂(t, q, p) * d²Hdq₁dp₂(t, q, p, params) +
-    dg₁dq₃(t, q, p) * d²Hdq₁dp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * d²Hdq₁dq₁(t, q, p, params) -
-    dg₁dp₂(t, q, p) * d²Hdq₁dq₂(t, q, p, params) -
-    dg₁dp₃(t, q, p) * d²Hdq₁dq₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₂dq₂(t, q, p, params) = +dλₒdq₂(t, q, p) * λ₂(t, q, p, params) / λₒ(t, q, p) - (
-    d²g₁dq₁dq₂(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₁dq₂dq₂(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₁dq₂dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₁dq₂dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₁dq₂dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₁dq₂dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₁dq₁(t, q, p) * d²Hdq₂dp₁(t, q, p, params) +
-    dg₁dq₂(t, q, p) * d²Hdq₂dp₂(t, q, p, params) +
-    dg₁dq₃(t, q, p) * d²Hdq₂dp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * d²Hdq₁dq₂(t, q, p, params) -
-    dg₁dp₂(t, q, p) * d²Hdq₂dq₂(t, q, p, params) -
-    dg₁dp₃(t, q, p) * d²Hdq₂dq₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₂dq₃(t, q, p, params) = +dλₒdq₃(t, q, p) * λ₂(t, q, p, params) / λₒ(t, q, p) - (
-    d²g₁dq₁dq₃(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₁dq₂dq₃(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₁dq₃dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₁dq₃dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₁dq₃dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₁dq₃dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₁dq₁(t, q, p) * d²Hdq₃dp₁(t, q, p, params) +
-    dg₁dq₂(t, q, p) * d²Hdq₃dp₂(t, q, p, params) +
-    dg₁dq₃(t, q, p) * d²Hdq₃dp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * d²Hdq₁dq₃(t, q, p, params) -
-    dg₁dp₂(t, q, p) * d²Hdq₂dq₃(t, q, p, params) -
-    dg₁dp₃(t, q, p) * d²Hdq₃dq₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₂dp₁(t, q, p, params) = +dλₒdp₁(t, q, p) * λ₂(t, q, p, params) / λₒ(t, q, p) - (
-    d²g₁dq₁dp₁(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₁dq₂dp₁(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₁dq₃dp₁(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₁dp₁dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₁dp₁dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₁dp₁dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₁dq₁(t, q, p) * d²Hdp₁dp₁(t, q, p, params) +
-    dg₁dq₂(t, q, p) * d²Hdp₁dp₂(t, q, p, params) +
-    dg₁dq₃(t, q, p) * d²Hdp₁dp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * d²Hdq₁dp₁(t, q, p, params) -
-    dg₁dp₂(t, q, p) * d²Hdq₂dp₁(t, q, p, params) -
-    dg₁dp₃(t, q, p) * d²Hdq₃dp₁(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₂dp₂(t, q, p, params) = +dλₒdp₂(t, q, p) * λ₂(t, q, p, params) / λₒ(t, q, p) - (
-    d²g₁dq₁dp₂(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₁dq₂dp₂(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₁dq₃dp₂(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₁dp₁dp₂(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₁dp₂dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₁dp₂dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₁dq₁(t, q, p) * d²Hdp₁dp₂(t, q, p, params) +
-    dg₁dq₂(t, q, p) * d²Hdp₂dp₂(t, q, p, params) +
-    dg₁dq₃(t, q, p) * d²Hdp₂dp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * d²Hdq₁dp₂(t, q, p, params) -
-    dg₁dp₂(t, q, p) * d²Hdq₂dp₂(t, q, p, params) -
-    dg₁dp₃(t, q, p) * d²Hdq₃dp₂(t, q, p, params)
-) / λₒ(t, q, p)
-
-dλ₂dp₃(t, q, p, params) = +dλₒdp₃(t, q, p) * λ₂(t, q, p, params) / λₒ(t, q, p) - (
-    d²g₁dq₁dp₃(t, q, p) * dHdp₁(t, q, p, params) +
-    d²g₁dq₂dp₃(t, q, p) * dHdp₂(t, q, p, params) +
-    d²g₁dq₃dp₃(t, q, p) * dHdp₃(t, q, p, params) -
-    d²g₁dp₁dp₃(t, q, p) * dHdq₁(t, q, p, params) -
-    d²g₁dp₂dp₃(t, q, p) * dHdq₂(t, q, p, params) -
-    d²g₁dp₃dp₃(t, q, p) * dHdq₃(t, q, p, params) +
-    dg₁dq₁(t, q, p) * d²Hdp₁dp₃(t, q, p, params) +
-    dg₁dq₂(t, q, p) * d²Hdp₂dp₃(t, q, p, params) +
-    dg₁dq₃(t, q, p) * d²Hdp₃dp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * d²Hdq₁dp₃(t, q, p, params) -
-    dg₁dp₂(t, q, p) * d²Hdq₂dp₃(t, q, p, params) -
-    dg₁dp₃(t, q, p) * d²Hdq₃dp₃(t, q, p, params)
-) / λₒ(t, q, p)
-
-
-function guiding_center_3d_canonical_v(v, t, q, p, params)
-    guiding_center_3d_v(v, t, q, p, params)
-
-    v[1] += dλ₁dp₁(t, q, p, params) * g₁(t, q, p) +
-            dλ₂dp₁(t, q, p, params) * g₂(t, q, p)
-    v[2] += dλ₁dp₂(t, q, p, params) * g₁(t, q, p) +
-            dλ₂dp₂(t, q, p, params) * g₂(t, q, p)
-    v[3] += dλ₁dp₃(t, q, p, params) * g₁(t, q, p) +
-            dλ₂dp₃(t, q, p, params) * g₂(t, q, p)
-
+    addcomponents!(v, i -> dλ₁dpⱼ(i, t, q, p, params, c) * g1 +
+                           dλ₂dpⱼ(i, t, q, p, params, c) * g2)
     nothing
 end
 
-function guiding_center_3d_canonical_f(f, t, q, p, params)
-    guiding_center_3d_f(f, t, q, p, params)
+function guiding_center_3d_canonical_f(f, t, q, p, params, c = default_constraint_pair())
+    guiding_center_3d_f(f, t, q, p, params, c)
 
-    f[1] -= dλ₁dq₁(t, q, p, params) * g₁(t, q, p) +
-            dλ₂dq₁(t, q, p, params) * g₂(t, q, p)
-    f[2] -= dλ₁dq₂(t, q, p, params) * g₁(t, q, p) +
-            dλ₂dq₂(t, q, p, params) * g₂(t, q, p)
-    f[3] -= dλ₁dq₃(t, q, p, params) * g₁(t, q, p) +
-            dλ₂dq₃(t, q, p, params) * g₂(t, q, p)
+    g1 = gᵏ(c[1], t, q, p)
+    g2 = gᵏ(c[2], t, q, p)
 
+    addcomponents!(f, i -> -dλ₁dqⱼ(i, t, q, p, params, c) * g1 -
+                            dλ₂dqⱼ(i, t, q, p, params, c) * g2)
     nothing
 end
 
@@ -697,16 +326,23 @@ end
     hodeproblem_canonical(x₀ = qᵢ; kwargs...)
     hodeproblem_canonical(ics::NamedTuple; kwargs...)
 
-The canonicalised guiding centre system, `H̄ = H + λ₁ g₁ + λ₂ g₂`, which agrees with
+The canonicalised guiding centre system, `H̃ = H + λ₁ g₁ + λ₂ g₂`, which agrees with
 [`hodeproblem`](@ref) on the constraint manifold but is genuinely canonical. Same three argument
-forms as `hodeproblem`.
+forms and the same `constraints` keyword as `hodeproblem`.
 """
 function hodeproblem_canonical(q₀::AbstractVector, p₀::AbstractVector; timespan = DEFAULT_TIMESPAN,
-                               timestep = DEFAULT_TIMESTEP, parameters = default_parameters(), periodic = true)
+                               timestep = DEFAULT_TIMESTEP, parameters = default_parameters(), periodic = true,
+                               constraints = default_constraints())
+    c = constraint_pair(constraints)
+
+    _v(v, t, q, p, params) = guiding_center_3d_canonical_v(v, t, q, p, params, c)
+    _f(f, t, q, p, params) = guiding_center_3d_canonical_f(f, t, q, p, params, c)
+    _h(t, q, p, params) = hamiltonian_canonical(t, q, p, params, c)
+
     HODEProblem(
-        guiding_center_3d_canonical_v,
-        guiding_center_3d_canonical_f,
-        hamiltonian_canonical,
+        _v,
+        _f,
+        _h,
         timespan, timestep, q₀, p₀;
         parameters=parameters,
         periodicity=guiding_center_3d_periodicity(q₀, periodic))
@@ -719,3 +355,7 @@ end
 
 hodeproblem_canonical(ics::NamedTuple; kwargs...) =
     hodeproblem_canonical(ics.q, ics.p; parameters = ics.params, kwargs...)
+
+
+# The compact form, Eq. (29), which drops the constraint-proportional terms from the right-hand side.
+include("guiding_center_3d_compact.jl")

--- a/src/guiding_center_3d/guiding_center_3d_compact.jl
+++ b/src/guiding_center_3d/guiding_center_3d_compact.jl
@@ -1,0 +1,200 @@
+#
+# The compact form of the Hamilton-Dirac guiding centre equations, Eq. (29) of Li, Zhang & Liu.
+#
+# Eq. (11) — what `hodeproblem` builds — carries `bₘ` in the denominator of both Lagrange
+# multipliers, with `m` the index of the constraint the pair omits. Rearranged, the right-hand side
+# splits into a part that is regular there and a part proportional to the constraints `gʲ`, which
+# vanish along the solution. Dropping the latter is Eq. (29), and removes all of the singularity bar
+# one factor of `(pₘ-Aₘ)/bₘ`; the last paragraph below is about removing that one too.
+#
+# The paper writes that rearrangement with Cartesian vector identities (`∇×b`, `b×∇B`) and
+# `H = ½Σ(pᵢ-Aᵢ)²`, which does not carry over: eight of the thirteen equilibria here are curvilinear
+# and the Hamiltonian of this package carries `g¹¹, g²², g³³`. It is derived below instead from the
+# objects the model already has, which makes it coordinate-general and, as it turns out, shorter.
+#
+# Write the constraints in the antisymmetric labelling `c = b × v`, so `cₗ = ε_{lab} bₐ v_b`, related
+# to the paper's by `c₁ = g²`, `c₂ = -g¹`, `c₃ = g³`. Then
+#
+#     ∂cₖ/∂pₗ = ε_{kal} bₐ                                                                    (i)
+#
+# with no metric in it. For the pair retaining `(cᵢ, cⱼ)`, the cyclic complement of `m`, the
+# multiplier contribution to `Ẋ` is
+#
+#     Cₗ = Σₖ λᵏ ∂cₖ/∂pₗ = -bₘ {cₗ, H} / {cᵢ, cⱼ} ,                                          (ii)
+#
+# uniformly in `l`: for `l ∈ {i, j}` this is exact algebra from (i), and for `l = m` it needs
+# `Σₗ bₗ cₗ = b·(b×v) = 0`, which holds identically and therefore gives `Σₗ bₗ {cₗ, H} = 0` on the
+# constraint manifold. That identity is the one thing Eq. (29) uses the constraints for.
+#
+# `{cᵢ, cⱼ} = bₘ D` with `D` the same for all three `m`, so the singular factor `bₘ / {cᵢ, cⱼ}`
+# may be replaced by `1/D` with
+#
+#     D = Σₘ bₘ {cᵢ, cⱼ}(m) / Σₘ bₘ bₘ ,                                                    (iii)
+#
+# whose denominator cannot vanish, since `|b| = 1`. What is left is free of every `bₘ` denominator
+# and no longer depends on which pair was chosen.
+#
+# The momentum equation follows the same way. Splitting `∂cₖ/∂qₗ` into its `∂b/∂x` and `∂A/∂x` parts,
+# the second contracts straight back into `C` through (i), and the first does too once `vₐ = u bₐ` is
+# used on the manifold:
+#
+#     ṗₗ = -∂H/∂qₗ + Σₐ (∂Aₐ/∂xₗ + u ∂bₐ/∂xₗ) Cₐ .                                          (iv)
+#
+# `u` is the parallel velocity. Eq. (29) as printed uses `(pₘ-Aₘ)/bₘ` for it, which is `0/0` exactly
+# where the formulation was singular to begin with; `u(t, q, p)` is the same quantity on the manifold
+# — `vₐ = bₐ u` and `|b| = 1` give `Σₐ vₐ gᵃᵃ bₐ = u` — and is regular everywhere. Passing
+# `constraints = :parallel`, the default, uses it together with (iii). Passing one of the pair
+# symbols reproduces the paper literally, singularity included, which is what
+# `scripts/study_guiding_center_3d_conditioning.jl` measures.
+#
+
+export hodeproblem_compact
+
+
+# `cₗ = σ gᵏ`: the antisymmetric labelling in terms of the paper's.
+cross_constraint(::Val{1}) = (Val(2), +1)
+cross_constraint(::Val{2}) = (Val(1), -1)
+cross_constraint(::Val{3}) = (Val(3), +1)
+
+# The two indices completing `m` to a positively oriented triple.
+cyclic_complement(::Val{1}) = (Val(2), Val(3))
+cyclic_complement(::Val{2}) = (Val(3), Val(1))
+cyclic_complement(::Val{3}) = (Val(1), Val(2))
+
+
+"""
+    cₗ(::Val{l}, t, q, p)
+
+The `l`-th component of `b × v`, which is the `l`-th constraint in the antisymmetric labelling.
+Related to the `gᵏ` of Li, Zhang & Liu by `c₁ = g²`, `c₂ = -g¹`, `c₃ = g³`, so the two sets vanish
+together.
+"""
+@inline function cₗ(l::Val, t, q, p)
+    k, σ = cross_constraint(l)
+    σ * gᵏ(k, t, q, p)
+end
+
+# {cₗ, H}
+@inline function bracket_cH(l::Val, t, q, p, params)
+    k, σ = cross_constraint(l)
+    σ * bracket_gH(k, t, q, p, params)
+end
+
+# {cᵢ, cⱼ} over the cyclic complement of `m`, which equals `bₘ [B + (p-A)·(∇×b)]`.
+@inline function bracket_cc(m::Val, t, q, p)
+    i, j = cyclic_complement(m)
+    kᵢ, σᵢ = cross_constraint(i)
+    kⱼ, σⱼ = cross_constraint(j)
+    σᵢ * σⱼ * bracket_gg(kᵢ, kⱼ, t, q, p)
+end
+
+
+"""
+    compact_denominator(t, q, p)
+
+The scalar `D = B + (p-A)·(∇×b)` of Eq. (29), obtained as `Σₘ bₘ {cᵢ, cⱼ}(m) / Σₘ bₘ bₘ` so that no
+single component of `b` ever divides. The three ratios `{cᵢ, cⱼ}(m) / bₘ` agree on the constraint
+manifold; this weighted mean of them is the combination that stays finite off it as well.
+"""
+compact_denominator(t, q, p) = contract(m -> bᵢ(m, t, q) * bracket_cc(m, t, q, p)) /
+                               contract(m -> bᵢ(m, t, q)^2)
+
+
+# The scalar the three brackets `{cₗ, H}` are divided by, Eq. (ii) above: regularised for
+# `:parallel`, literal for a constraint pair whose omitted index is `m`.
+@inline compact_scale(t, q, p, ::Nothing) = -inv(compact_denominator(t, q, p))
+@inline compact_scale(t, q, p, m::Val) = -bᵢ(m, t, q) / bracket_cc(m, t, q, p)
+
+"""
+    compact_multipliers(t, q, p, params, m)
+
+The three components of `Cₗ`, the multiplier contribution to `Ẋ`, as a tuple. All three share the
+same denominator, and it is the expensive part of the expression — nine Poisson-bracket terms — so
+they are computed together rather than one at a time.
+"""
+@inline function compact_multipliers(t, q, p, params, m)
+    s = compact_scale(t, q, p, m)
+    (s * bracket_cH(Val(1), t, q, p, params),
+     s * bracket_cH(Val(2), t, q, p, params),
+     s * bracket_cH(Val(3), t, q, p, params))
+end
+
+# Index a tuple with a compile-time index, so that it stays one.
+@inline component(x::Tuple, ::Val{i}) where {i} = x[i]
+
+# The parallel velocity entering Eq. (iv), likewise dispatching on the choice of form.
+@inline compact_parallel_velocity(t, q, p, ::Nothing) = u(t, q, p)
+@inline compact_parallel_velocity(t, q, p, m::Val{i}) where {i} = (p[i] - Aᵢ(m, t, q)) / bᵢ(m, t, q)
+
+
+"""
+    compact_index(constraints::Symbol)
+
+The index of the constraint a pair omits, which is the component of `b` the multipliers of that pair
+divide by: `:g31 → 1`, `:g23 → 2`, `:g12 → 3`. `:parallel` maps to `nothing`, selecting the
+regularised, pair-independent form of the compact equations.
+"""
+compact_index(::Val{:parallel}) = nothing
+compact_index(::Val{:g31}) = Val(1)
+compact_index(::Val{:g23}) = Val(2)
+compact_index(::Val{:g12}) = Val(3)
+
+compact_index(constraints::Symbol) = compact_index(Val(constraints))
+
+
+function guiding_center_3d_compact_v(v, t, q, p, params, m = nothing)
+    C = compact_multipliers(t, q, p, params, m)
+
+    components!(v, i -> dHdpᵢ(i, t, q, p, params) + component(C, i))
+    nothing
+end
+
+function guiding_center_3d_compact_f(f, t, q, p, params, m = nothing)
+    C = compact_multipliers(t, q, p, params, m)
+    uₚ = compact_parallel_velocity(t, q, p, m)
+
+    components!(f, l -> -dHdqᵢ(l, t, q, p, params) +
+        contract(a -> (dAᵢdxⱼ(a, l, t, q) + uₚ * dbᵢdxⱼ(a, l, t, q)) * component(C, a)))
+    nothing
+end
+
+
+"""
+    hodeproblem_compact(q₀, p₀; kwargs...)
+    hodeproblem_compact(x₀ = qᵢ; kwargs...)
+    hodeproblem_compact(ics::NamedTuple; kwargs...)
+
+The compact form of the guiding centre system, Eq. (29) of Li, Zhang & Liu, which drops the terms
+proportional to the constraints from the right-hand side of [`hodeproblem`](@ref). The two agree on
+the constraint manifold. Same three argument forms as `hodeproblem`.
+
+`constraints` defaults to `:parallel`, the derivation at the top of
+`src/guiding_center_3d/guiding_center_3d_compact.jl`: coordinate-general, independent of the
+constraint pair, and free of the `bₘ = 0` singularity, which is the point of this formulation.
+Passing `:g31`, `:g12` or `:g23` instead reproduces the paper's expressions literally for that pair,
+`bₘ` in the denominator included.
+"""
+function hodeproblem_compact(q₀::AbstractVector, p₀::AbstractVector; timespan = DEFAULT_TIMESPAN,
+                             timestep = DEFAULT_TIMESTEP, parameters = default_parameters(), periodic = true,
+                             constraints = :parallel)
+    m = compact_index(constraints)
+
+    _v(v, t, q, p, params) = guiding_center_3d_compact_v(v, t, q, p, params, m)
+    _f(f, t, q, p, params) = guiding_center_3d_compact_f(f, t, q, p, params, m)
+
+    HODEProblem(
+        _v,
+        _f,
+        hamiltonian,
+        timespan, timestep, q₀, p₀;
+        parameters=parameters,
+        periodicity=guiding_center_3d_periodicity(q₀, periodic))
+end
+
+function hodeproblem_compact(x₀::AbstractVector = qᵢ; timespan = DEFAULT_TIMESPAN, kwargs...)
+    ics = initial_conditions(timespan[begin], x₀)
+    hodeproblem_compact(ics.q, ics.p; timespan = timespan, kwargs...)
+end
+
+hodeproblem_compact(ics::NamedTuple; kwargs...) =
+    hodeproblem_compact(ics.q, ics.p; parameters = ics.params, kwargs...)

--- a/src/guiding_center_3d/guiding_center_3d_compact.jl
+++ b/src/guiding_center_3d/guiding_center_3d_compact.jl
@@ -31,8 +31,12 @@
 #
 #     D = Σₘ bₘ {cᵢ, cⱼ}(m) / Σₘ bₘ bₘ ,                                                    (iii)
 #
-# whose denominator cannot vanish, since `|b| = 1`. What is left is free of every `bₘ` denominator
-# and no longer depends on which pair was chosen.
+# whose denominator cannot vanish: the `bᵢ` are covariant components, so what is normalised is
+# `Σᵢ gⁱⁱ bᵢ bᵢ = 1` rather than `Σᵢ bᵢ bᵢ` — the latter is 6.25 on the ITER Solov'ev X-point and 1.11
+# on the toroidal tokamak — but the metric is positive definite, so `Σᵢ bᵢ bᵢ` can only vanish where
+# every `bᵢ` does, which the normalisation forbids. (iii) is a weighted mean and therefore exact for
+# any positive weights; `Σₘ bₘ bₘ` is chosen because it needs nothing the model does not already have.
+# What is left is free of every `bₘ` denominator and no longer depends on which pair was chosen.
 #
 # The momentum equation follows the same way. Splitting `∂cₖ/∂qₗ` into its `∂b/∂x` and `∂A/∂x` parts,
 # the second contracts straight back into `C` through (i), and the first does too once `vₐ = u bₐ` is
@@ -42,10 +46,25 @@
 #
 # `u` is the parallel velocity. Eq. (29) as printed uses `(pₘ-Aₘ)/bₘ` for it, which is `0/0` exactly
 # where the formulation was singular to begin with; `u(t, q, p)` is the same quantity on the manifold
-# — `vₐ = bₐ u` and `|b| = 1` give `Σₐ vₐ gᵃᵃ bₐ = u` — and is regular everywhere. Passing
-# `constraints = :parallel`, the default, uses it together with (iii). Passing one of the pair
-# symbols reproduces the paper literally, singularity included, which is what
-# `scripts/study_guiding_center_3d_conditioning.jl` measures.
+# — `vₐ = bₐ u` and `Σₐ gᵃᵃ bₐ bₐ = 1` give `Σₐ vₐ gᵃᵃ bₐ = u` — and is regular everywhere.
+#
+# So there are two places the pair can enter, and `constraints` selects between them together:
+#
+#   * `:parallel`, the default, takes the scale from (iii) and the parallel velocity from `u(t, q, p)`.
+#     Neither divides by a component of `b`, so the whole right-hand side is regular and independent of
+#     the pair.
+#   * a pair symbol takes the scale from that pair's own bracket, `bₘ / {cᵢ, cⱼ}(m)`, and the parallel
+#     velocity from `(pₘ-Aₘ)/bₘ`. *Both* of those are `0/0` where the pair's multipliers were singular,
+#     so this variant inherits the singularity twice over rather than once.
+#
+# Only the second of those two is Eq. (29) as printed: the paper evaluates the scale from `D` written
+# out as `|B| + (p-A)·(∇×b)`, which is regular. Taking it from the pair's own bracket instead is a
+# choice made here, and the reason this variant is the cheapest of the three formulations — three
+# bracket terms rather than the nine that (iii) averages, which is where the 0.86-0.95 relative cost in
+# `docs/src/findings.md` comes from. It is kept because it is the only way to exhibit the pair
+# dependence of Eq. (29) at all, which is what
+# `scripts/study_guiding_center_3d_conditioning.jl` measures; `test/structure_tests.jl` pins both
+# variants against Eq. (29) spelled out from the field functions.
 #
 
 export hodeproblem_compact
@@ -80,7 +99,10 @@ end
     σ * bracket_gH(k, t, q, p, params)
 end
 
-# {cᵢ, cⱼ} over the cyclic complement of `m`, which equals `bₘ [B + (p-A)·(∇×b)]`.
+# {cᵢ, cⱼ} over the cyclic complement of `m`, which equals `bₘ [B + (p-A)·(∇×b)]`. Unsigned, unlike
+# `λₒ`: the cyclic ordering of the antisymmetric labelling fixes the sign here, whereas `λₒ` is the
+# bracket of a pair of `gᵏ` in the order the multipliers see them, and that ordering puts a minus in
+# front of `b₂` for `(g², g³)`. See `constraint_pair`.
 @inline function bracket_cc(m::Val, t, q, p)
     i, j = cyclic_complement(m)
     kᵢ, σᵢ = cross_constraint(i)
@@ -95,13 +117,22 @@ end
 The scalar `D = B + (p-A)·(∇×b)` of Eq. (29), obtained as `Σₘ bₘ {cᵢ, cⱼ}(m) / Σₘ bₘ bₘ` so that no
 single component of `b` ever divides. The three ratios `{cᵢ, cⱼ}(m) / bₘ` agree on the constraint
 manifold; this weighted mean of them is the combination that stays finite off it as well.
+
+`Σₘ bₘ bₘ` cannot vanish, but not because it is one — the `bₘ` are covariant components, so the
+normalisation is `Σₘ gᵐᵐ bₘ bₘ = 1` and `Σₘ bₘ bₘ` is 6.25 on `SolovevIterXpoint`. It cannot vanish
+because the metric is positive definite, so the normalisation forbids every `bₘ` being zero at once.
+The mean is exact for any positive weights, so this makes no difference to `D`; in a cartesian chart
+the two coincide.
 """
 compact_denominator(t, q, p) = contract(m -> bᵢ(m, t, q) * bracket_cc(m, t, q, p)) /
                                contract(m -> bᵢ(m, t, q)^2)
 
 
-# The scalar the three brackets `{cₗ, H}` are divided by, Eq. (ii) above: regularised for
-# `:parallel`, literal for a constraint pair whose omitted index is `m`.
+# The scalar the three brackets `{cₗ, H}` are divided by, Eq. (ii) above. `:parallel` takes it from the
+# pair-independent `D`; a pair takes it from that pair's own bracket, which is `0/0` at `bₘ = 0`. The
+# paper computes it from `D` written out in cartesian form and so has no singularity here — this is the
+# first of the two `bₘ` denominators the pair variants carry, and the one that is a choice made here.
+# See the header.
 @inline compact_scale(t, q, p, ::Nothing) = -inv(compact_denominator(t, q, p))
 @inline compact_scale(t, q, p, m::Val) = -bᵢ(m, t, q) / bracket_cc(m, t, q, p)
 
@@ -171,8 +202,13 @@ the constraint manifold. Same three argument forms as `hodeproblem`.
 `constraints` defaults to `:parallel`, the derivation at the top of
 `src/guiding_center_3d/guiding_center_3d_compact.jl`: coordinate-general, independent of the
 constraint pair, and free of the `bₘ = 0` singularity, which is the point of this formulation.
-Passing `:g31`, `:g12` or `:g23` instead reproduces the paper's expressions literally for that pair,
-`bₘ` in the denominator included.
+
+Passing `:g31`, `:g12` or `:g23` instead ties the right-hand side to that pair in two places — the
+multiplier scale `bₘ/{cᵢ,cⱼ}(m)` and the parallel velocity `(pₘ-Aₘ)/bₘ`, both `0/0` where the pair's
+multipliers were singular. Only the second of the two is Eq. (29) as printed; the paper evaluates the
+scale from `D` in its cartesian form, which is regular. Taking it from the pair's own bracket is a
+choice made here, and is what makes this the cheapest of the three formulations. Use it to exhibit the
+pair dependence of Eq. (29), not to integrate with.
 """
 function hodeproblem_compact(q₀::AbstractVector, p₀::AbstractVector; timespan = DEFAULT_TIMESPAN,
                              timestep = DEFAULT_TIMESTEP, parameters = default_parameters(), periodic = true,

--- a/src/guiding_center_3d/guiding_center_3d_constraints.jl
+++ b/src/guiding_center_3d/guiding_center_3d_constraints.jl
@@ -9,8 +9,9 @@
 #
 # Any two of them may serve as the constraint pair. The Poisson bracket `{gⁱ, gʲ}` that divides both
 # Lagrange multipliers carries a factor of the `b`-component belonging to the *omitted* constraint —
-# `b₃` for the pair `(g¹, g²)`, `b₁` for `(g³, g¹)`, `b₂` for `(g², g³)` — so which pair is usable is
-# a property of the equilibrium and of where the orbit sits in it. See `constraint_pair` below.
+# `+b₃` for the pair `(g¹, g²)`, `+b₁` for `(g³, g¹)`, `-b₂` for `(g², g³)` — so which pair is usable
+# is a property of the equilibrium and of where the orbit sits in it. The sign varies with the pair's
+# ordering and does not matter; see `constraint_pair` below.
 #
 # The three are one indexed family, `gᵏ = b_i v_j - b_j v_i` with `(i, j)` from
 # `constraint_indices`, and so are their derivatives. Writing them out per index is what made
@@ -69,16 +70,37 @@ constraint_indices(::Val{3}) = (Val(1), Val(2))
 
 
 """
+    unval(::Val{i})
+
+The integer a `Val` index carries. `constraint_pair` and `compact_index` hand out `Val`s so that the
+right-hand side stays specialised on them, and nothing inside the right-hand side ever needs the
+integer back; this is for the callers outside it — the test suite and the scripts — that have to index
+a tuple of data series by a constraint index.
+
+Deliberately not defined for the `nothing` that `compact_index(:parallel)` returns: `:parallel` retains
+no pair, so there is no index to unwrap and asking for one is a mistake rather than a special case.
+"""
+unval(::Val{i}) where {i} = i
+
+
+"""
     constraint_pair(constraints::Symbol)
 
 The two constraints selected by the `constraints` keyword of the problem constructors, in the order
 they enter the multipliers:
 
-| symbol | pair | multiplier denominator |
+| symbol | pair | multiplier denominator `{g₁, g₂}` |
 |---|---|---|
-| `:g31` | `(g³, g¹)` | `b₁ [B + (p-A)·(∇×b)]` |
-| `:g12` | `(g¹, g²)` | `b₃ [B + (p-A)·(∇×b)]` |
-| `:g23` | `(g², g³)` | `b₂ [B + (p-A)·(∇×b)]` |
+| `:g31` | `(g³, g¹)` | `+b₁ [B + (p-A)·(∇×b)]` |
+| `:g12` | `(g¹, g²)` | `+b₃ [B + (p-A)·(∇×b)]` |
+| `:g23` | `(g², g³)` | `-b₂ [B + (p-A)·(∇×b)]` |
+
+The sign is not uniform, and the minus on `:g23` is not a typo: in the antisymmetric labelling
+`c₁ = g²`, `c₂ = -g¹`, `c₃ = g³` the bracket over a cyclic pair is `+bₘ [ … ]`, and `(g², g³)` is the
+one of the three whose ordering here reverses that cycle — `{g², g³} = {c₁, c₃} = -{c₃, c₁}`. It makes
+no difference to the dynamics, since reversing a pair's order flips `λₒ` and both multipliers together
+and the products `λ₁ ∂g₁ + λ₂ ∂g₂` are invariant, but it does mean `λₒ` and `bₘ` need not share a sign.
+The measured values in `docs/src/findings.md` show it.
 
 `:g31` is the pair the package implemented before the others existed. Which of the three is usable
 is a property of the equilibrium, so each one declares its own `default_constraints` beside its

--- a/src/guiding_center_3d/guiding_center_3d_constraints.jl
+++ b/src/guiding_center_3d/guiding_center_3d_constraints.jl
@@ -1,0 +1,158 @@
+#
+# The constraints of the 3D guiding centre model, written once against a running index.
+#
+# The degenerate Legendre transform of the guiding centre Lagrangian gives `pᵢ = bᵢ (b·Ẋ) + Aᵢ`, so
+# the three momenta are tied together by `v × b = 0` with `v = p - A`. Two of the three components
+# are independent, and Li, Zhang & Liu label them
+#
+#     g¹ = b₁ v₃ - b₃ v₁ ,    g² = b₂ v₃ - b₃ v₂ ,    g³ = b₁ v₂ - b₂ v₁ .
+#
+# Any two of them may serve as the constraint pair. The Poisson bracket `{gⁱ, gʲ}` that divides both
+# Lagrange multipliers carries a factor of the `b`-component belonging to the *omitted* constraint —
+# `b₃` for the pair `(g¹, g²)`, `b₁` for `(g³, g¹)`, `b₂` for `(g², g³)` — so which pair is usable is
+# a property of the equilibrium and of where the orbit sits in it. See `constraint_pair` below.
+#
+# The three are one indexed family, `gᵏ = b_i v_j - b_j v_i` with `(i, j)` from
+# `constraint_indices`, and so are their derivatives. Writing them out per index is what made
+# `guiding_center_3d_canonical.jl` seven hundred lines long and is why only one pair was ever
+# implemented.
+#
+# `ElectromagneticFields.@code()` injects the field functions under names carrying literal
+# subscripts — `b₁`, `db₂dx₃`, `d²A₁dx₂dx₃` — so the generic expressions need index accessors for
+# them. Those take `Val`s rather than `Int`s: the index is then part of the signature, every call
+# inlines to the injected function it stands for, and no dynamic dispatch survives into the
+# right-hand side. Their names must avoid the injected ones, of which `A`, `a`, `b`, `c`, `B`, `E`,
+# `g`, `φ`, `DF`, `J` and the `aₚ`/`a⃗` triads are all taken; hence the `ᵢ`/`ⱼ`/`ₖ` suffixes.
+#
+
+const INDEX_SUBSCRIPTS = ('₁', '₂', '₃')
+
+for i in 1:3
+    @eval @inline Aᵢ(::Val{$i}, t, q) = $(Symbol("A", INDEX_SUBSCRIPTS[i]))(t, q)
+    @eval @inline bᵢ(::Val{$i}, t, q) = $(Symbol("b", INDEX_SUBSCRIPTS[i]))(t, q)
+
+    for j in 1:3
+        @eval @inline dAᵢdxⱼ(::Val{$i}, ::Val{$j}, t, q) = $(Symbol("dA", INDEX_SUBSCRIPTS[i], "dx", INDEX_SUBSCRIPTS[j]))(t, q)
+        @eval @inline dbᵢdxⱼ(::Val{$i}, ::Val{$j}, t, q) = $(Symbol("db", INDEX_SUBSCRIPTS[i], "dx", INDEX_SUBSCRIPTS[j]))(t, q)
+
+        for k in 1:3
+            @eval @inline d²Aᵢdxⱼdxₖ(::Val{$i}, ::Val{$j}, ::Val{$k}, t, q) = $(Symbol("d²A", INDEX_SUBSCRIPTS[i], "dx", INDEX_SUBSCRIPTS[j], "dx", INDEX_SUBSCRIPTS[k]))(t, q)
+            @eval @inline d²bᵢdxⱼdxₖ(::Val{$i}, ::Val{$j}, ::Val{$k}, t, q) = $(Symbol("d²b", INDEX_SUBSCRIPTS[i], "dx", INDEX_SUBSCRIPTS[j], "dx", INDEX_SUBSCRIPTS[k]))(t, q)
+        end
+    end
+end
+
+
+# Contraction over the three coordinate directions. Written as a sum of three calls rather than a
+# loop or a generator so that the `Val` index stays a compile-time constant in each summand.
+@inline contract(f) = f(Val(1)) + f(Val(2)) + f(Val(3))
+
+
+vᵢ(::Val{i}, t, q, p) where {i} = p[i] - Aᵢ(Val(i), t, q)
+
+dvᵢdqⱼ(i::Val, j::Val, t, q, p) = -dAᵢdxⱼ(i, j, t, q)
+dvᵢdpⱼ(::Val{i}, ::Val{j}, t, q, p) where {i,j} = i == j ? one(eltype(p)) : zero(eltype(p))
+
+d²vᵢdqⱼdqₖ(i::Val, j::Val, k::Val, t, q, p) = -d²Aᵢdxⱼdxₖ(i, j, k, t, q)
+
+
+"""
+    constraint_indices(::Val{k})
+
+The pair `(i, j)` of field indices the `k`-th constraint `gᵏ = bᵢ vⱼ - bⱼ vᵢ` is built from, as
+`Val`s so that the caller keeps compile-time indices. The labelling is that of Li, Zhang & Liu:
+`g¹ = b₁v₃ - b₃v₁`, `g² = b₂v₃ - b₃v₂`, `g³ = b₁v₂ - b₂v₁`.
+"""
+constraint_indices(::Val{1}) = (Val(1), Val(3))
+constraint_indices(::Val{2}) = (Val(2), Val(3))
+constraint_indices(::Val{3}) = (Val(1), Val(2))
+
+
+"""
+    constraint_pair(constraints::Symbol)
+
+The two constraints selected by the `constraints` keyword of the problem constructors, in the order
+they enter the multipliers:
+
+| symbol | pair | multiplier denominator |
+|---|---|---|
+| `:g31` | `(g³, g¹)` | `b₁ [B + (p-A)·(∇×b)]` |
+| `:g12` | `(g¹, g²)` | `b₃ [B + (p-A)·(∇×b)]` |
+| `:g23` | `(g², g³)` | `b₂ [B + (p-A)·(∇×b)]` |
+
+`:g31` is the pair the package implemented before the others existed. Which of the three is usable
+is a property of the equilibrium, so each one declares its own `default_constraints` beside its
+`default_parameters`.
+"""
+constraint_pair(::Val{:g31}) = (Val(3), Val(1))
+constraint_pair(::Val{:g12}) = (Val(1), Val(2))
+constraint_pair(::Val{:g23}) = (Val(2), Val(3))
+
+constraint_pair(constraints::Symbol) = constraint_pair(Val(constraints))
+
+default_constraint_pair() = constraint_pair(default_constraints())
+
+
+"""
+    gᵏ(::Val{k}, t, q, p)
+
+The `k`-th constraint, `gᵏ = bᵢ vⱼ - bⱼ vᵢ` with `(i, j) = constraint_indices(Val(k))`. All three
+vanish on the constraint manifold, whichever pair a problem was built with.
+"""
+@inline function gᵏ(k::Val, t, q, p)
+    i, j = constraint_indices(k)
+    bᵢ(i, t, q) * vᵢ(j, t, q, p) - bᵢ(j, t, q) * vᵢ(i, t, q, p)
+end
+
+@inline function dgᵏdqₗ(k::Val, l::Val, t, q, p)
+    i, j = constraint_indices(k)
+    (dbᵢdxⱼ(i, l, t, q) * vᵢ(j, t, q, p) + bᵢ(i, t, q) * dvᵢdqⱼ(j, l, t, q, p)) -
+    (dbᵢdxⱼ(j, l, t, q) * vᵢ(i, t, q, p) + bᵢ(j, t, q) * dvᵢdqⱼ(i, l, t, q, p))
+end
+
+@inline function dgᵏdpₗ(k::Val, l::Val, t, q, p)
+    i, j = constraint_indices(k)
+    bᵢ(i, t, q) * dvᵢdpⱼ(j, l, t, q, p) - bᵢ(j, t, q) * dvᵢdpⱼ(i, l, t, q, p)
+end
+
+@inline function d²gᵏdqₗdqₘ(k::Val, l::Val, m::Val, t, q, p)
+    i, j = constraint_indices(k)
+    (d²bᵢdxⱼdxₖ(i, l, m, t, q) * vᵢ(j, t, q, p) +
+     dbᵢdxⱼ(i, l, t, q) * dvᵢdqⱼ(j, m, t, q, p) +
+     dbᵢdxⱼ(i, m, t, q) * dvᵢdqⱼ(j, l, t, q, p) +
+     bᵢ(i, t, q) * d²vᵢdqⱼdqₖ(j, l, m, t, q, p)) -
+    (d²bᵢdxⱼdxₖ(j, l, m, t, q) * vᵢ(i, t, q, p) +
+     dbᵢdxⱼ(j, l, t, q) * dvᵢdqⱼ(i, m, t, q, p) +
+     dbᵢdxⱼ(j, m, t, q) * dvᵢdqⱼ(i, l, t, q, p) +
+     bᵢ(j, t, q) * d²vᵢdqⱼdqₖ(i, l, m, t, q, p))
+end
+
+@inline function d²gᵏdqₗdpₘ(k::Val, l::Val, m::Val, t, q, p)
+    i, j = constraint_indices(k)
+    dbᵢdxⱼ(i, l, t, q) * dvᵢdpⱼ(j, m, t, q, p) - dbᵢdxⱼ(j, l, t, q) * dvᵢdpⱼ(i, m, t, q, p)
+end
+
+# ∂²gᵏ/∂pₗ∂pₘ vanishes identically — `gᵏ` is linear in `p`. Every contraction below therefore drops
+# the terms it would contribute rather than multiplying by an exact zero, which also keeps a `NaN`
+# elsewhere in the expression from spreading through a `0 * Inf`.
+
+
+"""
+    g₁(t, q, p)
+    g₂(t, q, p)
+    g₃(t, q, p)
+
+The three constraints under the labelling of Li, Zhang & Liu, `gᵏ` evaluated at a fixed `k`. Note
+that `g₁` and `g₂` used to name the members of the one implemented pair, which were `g³` and `g¹` in
+this labelling; all three vanish on the constraint manifold either way.
+"""
+g₁(t, q, p) = gᵏ(Val(1), t, q, p)
+g₂(t, q, p) = gᵏ(Val(2), t, q, p)
+g₃(t, q, p) = gᵏ(Val(3), t, q, p)
+
+# The constraints do not depend on the parameters, but `GeometricSolutions.compute_invariant` calls
+# what it is given as `f(t, q, p, params)`, so these are the forms that can be passed to it — as
+# `docs/src/examples/iter_cylindrical.md` does.
+g₁(t, q, p, params) = g₁(t, q, p)
+g₂(t, q, p, params) = g₂(t, q, p)
+g₃(t, q, p, params) = g₃(t, q, p)

--- a/src/guiding_center_3d/guiding_center_3d_diagnostics.jl
+++ b/src/guiding_center_3d/guiding_center_3d_diagnostics.jl
@@ -59,18 +59,25 @@ compute_toroidal_momentum_error(sol::GeometricSolution, params=GeometricEquation
 @doc raw"""
     compute_constraints(sol)
 
-The two constraints ``g_{1}`` and ``g_{2}`` that confine the solution to the manifold on which the
-momentum equals the guiding centre one-form, returned as a named tuple of two `DataSeries`.
+All three constraints ``g^{1}``, ``g^{2}``, ``g^{3}`` that confine the solution to the manifold on
+which the momentum equals the guiding centre one-form, returned as a named tuple of three
+`DataSeries`.
+
+Any two of the three make up the constraint pair a problem was built with — see
+[`constraint_pair`](@ref) — but all three vanish along the flow whichever pair that was, so
+reporting all three is independent of the choice and shows a drift that is invisible in the retained
+pair alone.
 
 They vanish identically along the continuous flow, so their magnitude measures how far a numerical
 solution has drifted off that manifold — the quantity the approximately symplectic methods of Li,
 Zhang and Liu are designed to keep bounded, and the one that decides whether `hodeproblem_canonical`
-agrees with `hodeproblem`. Since they start at zero, the absolute value is the meaningful one; there is no
-relative-error variant.
+and `hodeproblem_compact` agree with `hodeproblem`. Since they start at zero, the absolute value is
+the meaningful one; there is no relative-error variant.
 """
 function compute_constraints(t::SolutionTimes, q::DataSeries, p::DataSeries)
     (g₁=DataSeries([g₁(t[i], q[i], p[i]) for i in eachindex(t)]),
-     g₂=DataSeries([g₂(t[i], q[i], p[i]) for i in eachindex(t)]))
+     g₂=DataSeries([g₂(t[i], q[i], p[i]) for i in eachindex(t)]),
+     g₃=DataSeries([g₃(t[i], q[i], p[i]) for i in eachindex(t)]))
 end
 
 compute_constraints(sol::GeometricSolution) = compute_constraints(sol.t, sol.q, sol.p)

--- a/src/guiding_center_3d/guiding_center_3d_equations.jl
+++ b/src/guiding_center_3d/guiding_center_3d_equations.jl
@@ -9,7 +9,8 @@ export hodeproblem, hodeproblem_canonical
 
 # The constraints and the index accessors every generic expression below is written with. Included
 # from here rather than from the equilibrium modules so that adding it did not need thirteen edits;
-# `include` resolves relative to the file containing the call.
+# `include` resolves relative to the file containing the call. The compact form is pulled in the same
+# way at the foot of this file.
 include("guiding_center_3d_constraints.jl")
 
 
@@ -145,9 +146,13 @@ end
     λₒ(t, q, p, c = default_constraint_pair())
 
 The Poisson bracket `{g₁, g₂}` of the two constraints of the pair `c`, which divides both Lagrange
-multipliers. It equals `bₘ [B + (p-A)·(∇×b)]` with `m` the index of the constraint the pair omits, so
+multipliers. It equals `±bₘ [B + (p-A)·(∇×b)]` with `m` the index of the constraint the pair omits, so
 it is where the formulation becomes singular — see
 `scripts/study_guiding_center_3d_conditioning.jl`.
+
+The sign depends on the pair's ordering and is `+` for `:g31` and `:g12`, `-` for `:g23`; see
+[`constraint_pair`](@ref). Only `λₒ = 0` matters for whether the pair is usable, so nothing turns on
+it, but `λₒ` and `bₘ` do not always share a sign and the tabulated values reflect that.
 """
 λₒ(t, q, p, c = default_constraint_pair()) = bracket_gg(c[1], c[2], t, q, p)
 
@@ -243,3 +248,9 @@ function hodeproblem(x₀::AbstractVector = qᵢ; timespan = DEFAULT_TIMESPAN, k
 end
 
 hodeproblem(ics::NamedTuple; kwargs...) = hodeproblem(ics.q, ics.p; parameters = ics.params, kwargs...)
+
+
+# The compact form, Eq. (29), which drops the constraint-proportional terms from the right-hand side.
+# It needs the brackets, the Hamiltonian gradients and `u` from this file, and nothing at all from
+# `guiding_center_3d_canonical.jl` — no second derivatives — so it is included here rather than there.
+include("guiding_center_3d_compact.jl")

--- a/src/guiding_center_3d/guiding_center_3d_equations.jl
+++ b/src/guiding_center_3d/guiding_center_3d_equations.jl
@@ -7,52 +7,30 @@ import GeometricSolutions: GeometricSolution, DataSeries, TimeSeries
 export hamiltonian, hamiltonian_canonical
 export hodeproblem, hodeproblem_canonical
 
+# The constraints and the index accessors every generic expression below is written with. Included
+# from here rather than from the equilibrium modules so that adding it did not need thirteen edits;
+# `include` resolves relative to the file containing the call.
+include("guiding_center_3d_constraints.jl")
+
 
 @views ϑ₁(t, Q) = A₁(t, Q[1:3]) + Q[4] * b₁(t, Q[1:3])
 @views ϑ₂(t, Q) = A₂(t, Q[1:3]) + Q[4] * b₂(t, Q[1:3])
 @views ϑ₃(t, Q) = A₃(t, Q[1:3]) + Q[4] * b₃(t, Q[1:3])
 
-v₁(t, q, p) = p[1] - A₁(t, q)
-v₂(t, q, p) = p[2] - A₂(t, q)
-v₃(t, q, p) = p[3] - A₃(t, q)
+# The named `v` and its first derivatives, kept because the second derivatives of the Hamiltonian in
+# `guiding_center_3d_canonical.jl` are written out per index and read better that way. They are
+# aliases of the generic accessors rather than second definitions of them.
+for i in 1:3
+    @eval $(Symbol("v", INDEX_SUBSCRIPTS[i]))(t, q, p) = vᵢ($(Val(i)), t, q, p)
 
-dv₁dq₁(t, q, p) = -dA₁dx₁(t, q)
-dv₁dq₂(t, q, p) = -dA₁dx₂(t, q)
-dv₁dq₃(t, q, p) = -dA₁dx₃(t, q)
-
-dv₂dq₁(t, q, p) = -dA₂dx₁(t, q)
-dv₂dq₂(t, q, p) = -dA₂dx₂(t, q)
-dv₂dq₃(t, q, p) = -dA₂dx₃(t, q)
-
-dv₃dq₁(t, q, p) = -dA₃dx₁(t, q)
-dv₃dq₂(t, q, p) = -dA₃dx₂(t, q)
-dv₃dq₃(t, q, p) = -dA₃dx₃(t, q)
-
-dv₁dp₁(t, q, p) = one(eltype(p))
-dv₁dp₂(t, q, p) = zero(eltype(p))
-dv₁dp₃(t, q, p) = zero(eltype(p))
-
-dv₂dp₁(t, q, p) = zero(eltype(p))
-dv₂dp₂(t, q, p) = one(eltype(p))
-dv₂dp₃(t, q, p) = zero(eltype(p))
-
-dv₃dp₁(t, q, p) = zero(eltype(p))
-dv₃dp₂(t, q, p) = zero(eltype(p))
-dv₃dp₃(t, q, p) = one(eltype(p))
+    for j in 1:3
+        @eval $(Symbol("dv", INDEX_SUBSCRIPTS[i], "dq", INDEX_SUBSCRIPTS[j]))(t, q, p) = dvᵢdqⱼ($(Val(i)), $(Val(j)), t, q, p)
+        @eval $(Symbol("dv", INDEX_SUBSCRIPTS[i], "dp", INDEX_SUBSCRIPTS[j]))(t, q, p) = dvᵢdpⱼ($(Val(i)), $(Val(j)), t, q, p)
+    end
+end
 
 
 u(t, q, p) = v₁(t, q, p) * g¹¹(t, q) * b₁(t, q) + v₂(t, q, p) * g²²(t, q) * b₂(t, q) + v₃(t, q, p) * g³³(t, q) * b₃(t, q)
-
-# dudq₁(t, q, p) = v₁(t, q, p) * db₁dx₁(t, q) + v₂(t, q, p) * db₂dx₁(t, q) + v₃(t, q, p) * db₃dx₁(t, q) +
-#                  dv₁dq₁(t, q, p) * b₁(t, q) + dv₂dq₁(t, q, p) * b₂(t, q) + dv₃dq₁(t, q, p) * b₃(t, q)
-# dudq₂(t, q, p) = v₁(t, q, p) * db₁dx₂(t, q) + v₂(t, q, p) * db₂dx₂(t, q) + v₃(t, q, p) * db₃dx₂(t, q) +
-#                  dv₁dq₂(t, q, p) * b₁(t, q) + dv₂dq₂(t, q, p) * b₂(t, q) + dv₃dq₂(t, q, p) * b₃(t, q)
-# dudq₃(t, q, p) = v₁(t, q, p) * db₁dx₃(t, q) + v₂(t, q, p) * db₂dx₃(t, q) + v₃(t, q, p) * db₃dx₃(t, q) +
-#                  dv₁dq₃(t, q, p) * b₁(t, q) + dv₂dq₃(t, q, p) * b₂(t, q) + dv₃dq₃(t, q, p) * b₃(t, q)
-
-# dudp₁(t, q, p) = b₁(t, q)
-# dudp₂(t, q, p) = b₂(t, q)
-# dudp₃(t, q, p) = b₃(t, q)
 
 
 function initial_momentum(tᵢ, Qᵢ::AbstractArray{T}) where {T<:Number}
@@ -105,8 +83,6 @@ hamiltonian(t, q, p, params) = g¹¹(t, q) * v₁(t, q, p)^2 / 2 + g²²(t, q) *
 # which is what `scripts/guiding_center_3d_*.jl` plot it for. It omitted `φ`, unlike `hamiltonian`
 # beside it, which made the two incomparable for any equilibrium with a potential.
 hamiltonian_u(t, q, p, params) = u(t, q, p)^2 / 2 + params.μ * B(t, q) + φ(t, q)
-hamiltonian_canonical(t, q, p, params) = hamiltonian(t, q, p, params) + λ₁(t, q, p, params) * g₁(t, q, p) +
-                                         λ₂(t, q, p, params) * g₂(t, q, p)
 
 
 dHdq₁(t, q, p, params) = v₁(t, q, p) * g¹¹(t, q) * dv₁dq₁(t, q, p) +
@@ -148,141 +124,83 @@ dHdp₃(t, q, p, params) = v₁(t, q, p) * g¹¹(t, q) * dv₁dp₃(t, q, p) +
                          v₂(t, q, p) * g²²(t, q) * dv₂dp₃(t, q, p) +
                          v₃(t, q, p) * g³³(t, q) * dv₃dp₃(t, q, p)
 
-
-# function dHdq(dH, t, q, p, params)
-#     dH[1] = dHdq₁(t, q, p, params)
-#     dH[2] = dHdq₂(t, q, p, params)
-#     dH[3] = dHdq₃(t, q, p, params)
-#     nothing
-# end
-
-# function dHdp(dH, t, q, p, params)
-#     dH[1] = dHdp₁(t, q, p, params)
-#     dH[2] = dHdp₂(t, q, p, params)
-#     dH[3] = dHdp₃(t, q, p, params)
-#     nothing
-# end
-
-g₁(t, q, p) = b₁(t, q) * v₂(t, q, p) - b₂(t, q) * v₁(t, q, p)
-g₂(t, q, p) = b₁(t, q) * v₃(t, q, p) - b₃(t, q) * v₁(t, q, p)
-# g₁(t, q, p) = b₁(t, q) * v₃(t, q, p) - b₃(t, q) * v₁(t, q, p)
-# g₂(t, q, p) = b₂(t, q) * v₃(t, q, p) - b₃(t, q) * v₂(t, q, p)
-
-g₁(t, q, p, params) = g₁(t, q, p)
-g₂(t, q, p, params) = g₂(t, q, p)
-
-dg₁dq₁(t, q, p) = (db₁dx₁(t, q) * v₂(t, q, p) + b₁(t, q) * dv₂dq₁(t, q, p)) -
-                  (db₂dx₁(t, q) * v₁(t, q, p) + b₂(t, q) * dv₁dq₁(t, q, p))
-dg₁dq₂(t, q, p) = (db₁dx₂(t, q) * v₂(t, q, p) + b₁(t, q) * dv₂dq₂(t, q, p)) -
-                  (db₂dx₂(t, q) * v₁(t, q, p) + b₂(t, q) * dv₁dq₂(t, q, p))
-dg₁dq₃(t, q, p) = (db₁dx₃(t, q) * v₂(t, q, p) + b₁(t, q) * dv₂dq₃(t, q, p)) -
-                  (db₂dx₃(t, q) * v₁(t, q, p) + b₂(t, q) * dv₁dq₃(t, q, p))
-
-dg₂dq₁(t, q, p) = (db₁dx₁(t, q) * v₃(t, q, p) + b₁(t, q) * dv₃dq₁(t, q, p)) -
-                  (db₃dx₁(t, q) * v₁(t, q, p) + b₃(t, q) * dv₁dq₁(t, q, p))
-dg₂dq₂(t, q, p) = (db₁dx₂(t, q) * v₃(t, q, p) + b₁(t, q) * dv₃dq₂(t, q, p)) -
-                  (db₃dx₂(t, q) * v₁(t, q, p) + b₃(t, q) * dv₁dq₂(t, q, p))
-dg₂dq₃(t, q, p) = (db₁dx₃(t, q) * v₃(t, q, p) + b₁(t, q) * dv₃dq₃(t, q, p)) -
-                  (db₃dx₃(t, q) * v₁(t, q, p) + b₃(t, q) * dv₁dq₃(t, q, p))
-
-dg₁dp₁(t, q, p) = b₁(t, q) * dv₂dp₁(t, q, p) - b₂(t, q) * dv₁dp₁(t, q, p)
-dg₁dp₂(t, q, p) = b₁(t, q) * dv₂dp₂(t, q, p) - b₂(t, q) * dv₁dp₂(t, q, p)
-dg₁dp₃(t, q, p) = b₁(t, q) * dv₂dp₃(t, q, p) - b₂(t, q) * dv₁dp₃(t, q, p)
-
-dg₂dp₁(t, q, p) = b₁(t, q) * dv₃dp₁(t, q, p) - b₃(t, q) * dv₁dp₁(t, q, p)
-dg₂dp₂(t, q, p) = b₁(t, q) * dv₃dp₂(t, q, p) - b₃(t, q) * dv₁dp₂(t, q, p)
-dg₂dp₃(t, q, p) = b₁(t, q) * dv₃dp₃(t, q, p) - b₃(t, q) * dv₁dp₃(t, q, p)
+for i in 1:3
+    @eval @inline dHdqᵢ(::Val{$i}, t, q, p, params) = $(Symbol("dHdq", INDEX_SUBSCRIPTS[i]))(t, q, p, params)
+    @eval @inline dHdpᵢ(::Val{$i}, t, q, p, params) = $(Symbol("dHdp", INDEX_SUBSCRIPTS[i]))(t, q, p, params)
+end
 
 
-# dg₁dq₁(t, q, p) = (db₁dx₁(t, q) * v₃(t, q, p) + b₁(t, q) * dv₃dq₁(t, q, p)) -
-#                   (db₃dx₁(t, q) * v₁(t, q, p) + b₃(t, q) * dv₁dq₁(t, q, p))
-# dg₁dq₂(t, q, p) = (db₁dx₂(t, q) * v₃(t, q, p) + b₁(t, q) * dv₃dq₂(t, q, p)) -
-#                   (db₃dx₂(t, q) * v₁(t, q, p) + b₃(t, q) * dv₁dq₂(t, q, p))
-# dg₁dq₃(t, q, p) = (db₁dx₃(t, q) * v₃(t, q, p) + b₁(t, q) * dv₃dq₃(t, q, p)) -
-#                   (db₃dx₃(t, q) * v₁(t, q, p) + b₃(t, q) * dv₁dq₃(t, q, p))
+# The two Poisson brackets the Lagrange multipliers are built from,
+# `{f, l} = Σᵢ (∂f/∂qᵢ ∂l/∂pᵢ - ∂f/∂pᵢ ∂l/∂qᵢ)`.
+@inline bracket_gg(k₁::Val, k₂::Val, t, q, p) = contract(l ->
+    dgᵏdqₗ(k₁, l, t, q, p) * dgᵏdpₗ(k₂, l, t, q, p) -
+    dgᵏdpₗ(k₁, l, t, q, p) * dgᵏdqₗ(k₂, l, t, q, p))
 
-# dg₂dq₁(t, q, p) = (db₂dx₁(t, q) * v₃(t, q, p) + b₂(t, q) * dv₃dq₁(t, q, p)) -
-#                   (db₃dx₁(t, q) * v₂(t, q, p) + b₃(t, q) * dv₂dq₁(t, q, p))
-# dg₂dq₂(t, q, p) = (db₂dx₂(t, q) * v₃(t, q, p) + b₂(t, q) * dv₃dq₂(t, q, p)) -
-#                   (db₃dx₂(t, q) * v₂(t, q, p) + b₃(t, q) * dv₂dq₂(t, q, p))
-# dg₂dq₃(t, q, p) = (db₂dx₃(t, q) * v₃(t, q, p) + b₂(t, q) * dv₃dq₃(t, q, p)) -
-#                   (db₃dx₃(t, q) * v₂(t, q, p) + b₃(t, q) * dv₂dq₃(t, q, p))
-
-# dg₁dp₁(t, q, p) = b₁(t, q) * dv₃dp₁(t, q, p) - b₃(t, q) * dv₁dp₁(t, q, p)
-# dg₁dp₂(t, q, p) = b₁(t, q) * dv₃dp₂(t, q, p) - b₃(t, q) * dv₁dp₂(t, q, p)
-# dg₁dp₃(t, q, p) = b₁(t, q) * dv₃dp₃(t, q, p) - b₃(t, q) * dv₁dp₃(t, q, p)
-
-# dg₂dp₁(t, q, p) = b₂(t, q) * dv₃dp₁(t, q, p) - b₃(t, q) * dv₂dp₁(t, q, p)
-# dg₂dp₂(t, q, p) = b₂(t, q) * dv₃dp₂(t, q, p) - b₃(t, q) * dv₂dp₂(t, q, p)
-# dg₂dp₃(t, q, p) = b₂(t, q) * dv₃dp₃(t, q, p) - b₃(t, q) * dv₂dp₃(t, q, p)
+@inline bracket_gH(k::Val, t, q, p, params) = contract(l ->
+    dgᵏdqₗ(k, l, t, q, p) * dHdpᵢ(l, t, q, p, params) -
+    dgᵏdpₗ(k, l, t, q, p) * dHdqᵢ(l, t, q, p, params))
 
 
-λₒ(t, q, p) = (
-    dg₁dq₁(t, q, p) * dg₂dp₁(t, q, p) +
-    dg₁dq₂(t, q, p) * dg₂dp₂(t, q, p) +
-    dg₁dq₃(t, q, p) * dg₂dp₃(t, q, p) -
-    dg₁dp₁(t, q, p) * dg₂dq₁(t, q, p) -
-    dg₁dp₂(t, q, p) * dg₂dq₂(t, q, p) -
-    dg₁dp₃(t, q, p) * dg₂dq₃(t, q, p)
-)
+"""
+    λₒ(t, q, p, c = default_constraint_pair())
 
-λ₁(t, q, p, params) = +(
-    dg₂dq₁(t, q, p) * dHdp₁(t, q, p, params) +
-    dg₂dq₂(t, q, p) * dHdp₂(t, q, p, params) +
-    dg₂dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    dg₂dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    dg₂dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    dg₂dp₃(t, q, p) * dHdq₃(t, q, p, params)
-) / λₒ(t, q, p)
+The Poisson bracket `{g₁, g₂}` of the two constraints of the pair `c`, which divides both Lagrange
+multipliers. It equals `bₘ [B + (p-A)·(∇×b)]` with `m` the index of the constraint the pair omits, so
+it is where the formulation becomes singular — see
+`scripts/study_guiding_center_3d_conditioning.jl`.
+"""
+λₒ(t, q, p, c = default_constraint_pair()) = bracket_gg(c[1], c[2], t, q, p)
 
-λ₂(t, q, p, params) = -(
-    dg₁dq₁(t, q, p) * dHdp₁(t, q, p, params) +
-    dg₁dq₂(t, q, p) * dHdp₂(t, q, p, params) +
-    dg₁dq₃(t, q, p) * dHdp₃(t, q, p, params) -
-    dg₁dp₁(t, q, p) * dHdq₁(t, q, p, params) -
-    dg₁dp₂(t, q, p) * dHdq₂(t, q, p, params) -
-    dg₁dp₃(t, q, p) * dHdq₃(t, q, p, params)
-) / λₒ(t, q, p)
+"""
+    λ₁(t, q, p, params, c = default_constraint_pair())
+    λ₂(t, q, p, params, c = default_constraint_pair())
+
+The two Lagrange multipliers, `λ₁ = {g₂, H} / {g₁, g₂}` and `λ₂ = -{g₁, H} / {g₁, g₂}`, for the
+constraint pair `c`.
+"""
+λ₁(t, q, p, params, c = default_constraint_pair()) = +bracket_gH(c[2], t, q, p, params) / λₒ(t, q, p, c)
+λ₂(t, q, p, params, c = default_constraint_pair()) = -bracket_gH(c[1], t, q, p, params) / λₒ(t, q, p, c)
+
+hamiltonian_canonical(t, q, p, params, c = default_constraint_pair()) =
+    hamiltonian(t, q, p, params) + λ₁(t, q, p, params, c) * gᵏ(c[1], t, q, p) +
+                                   λ₂(t, q, p, params, c) * gᵏ(c[2], t, q, p)
 
 
+# Fill or accumulate into the three components of a right-hand side from a function of the
+# compile-time index.
+@inline function components!(x, f)
+    x[1] = f(Val(1))
+    x[2] = f(Val(2))
+    x[3] = f(Val(3))
+    x
+end
 
-# function guiding_center_3d_ode_v(v, t, x, params)
-#     q = @views x[1:3]
-#     p = @views x[4:6]
-
-#     v[1] = dHdp₁(t, q, p, params) + λ₁(t, q, p, params) * dg₁dp₁(t, q, p) + λ₂(t, q, p, params) * dg₂dp₁(t, q, p)
-#     v[2] = dHdp₂(t, q, p, params) + λ₁(t, q, p, params) * dg₁dp₂(t, q, p) + λ₂(t, q, p, params) * dg₂dp₂(t, q, p)
-#     v[3] = dHdp₃(t, q, p, params) + λ₁(t, q, p, params) * dg₁dp₃(t, q, p) + λ₂(t, q, p, params) * dg₂dp₃(t, q, p)
-#     v[4] = -dHdq₁(t, q, p, params) - λ₁(t, q, p, params) * dg₁dq₁(t, q, p) - λ₂(t, q, p, params) * dg₂dq₁(t, q, p)
-#     v[5] = -dHdq₂(t, q, p, params) - λ₁(t, q, p, params) * dg₁dq₂(t, q, p) - λ₂(t, q, p, params) * dg₂dq₂(t, q, p)
-#     v[6] = -dHdq₃(t, q, p, params) - λ₁(t, q, p, params) * dg₁dq₃(t, q, p) - λ₂(t, q, p, params) * dg₂dq₃(t, q, p)
-
-#     nothing
-# end
-
-# function ode(x₀, parameters; timespan = DEFAULT_TIMESPAN, timestep = DEFAULT_TIMESTEP, periodic=false)
-#     # println("3D Guiding Center model initial constraints g₁ = $(g₁(t₀, q₀, p₀)) and g₂ = $(g₂(t₀, q₀, p₀))")
-#     ODEProblem(
-#         guiding_center_3d_ode_v,
-#         timespan, timestep, x₀;
-#         parameters=parameters,
-#         periodicity=guiding_center_3d_periodicity(q₀, periodic))
-# end
+@inline function addcomponents!(x, f)
+    x[1] += f(Val(1))
+    x[2] += f(Val(2))
+    x[3] += f(Val(3))
+    x
+end
 
 
-function guiding_center_3d_v(v, t, q, p, params)
-    v[1] = dHdp₁(t, q, p, params) + λ₁(t, q, p, params) * dg₁dp₁(t, q, p) + λ₂(t, q, p, params) * dg₂dp₁(t, q, p)
-    v[2] = dHdp₂(t, q, p, params) + λ₁(t, q, p, params) * dg₁dp₂(t, q, p) + λ₂(t, q, p, params) * dg₂dp₂(t, q, p)
-    v[3] = dHdp₃(t, q, p, params) + λ₁(t, q, p, params) * dg₁dp₃(t, q, p) + λ₂(t, q, p, params) * dg₂dp₃(t, q, p)
+function guiding_center_3d_v(v, t, q, p, params, c = default_constraint_pair())
+    l₁ = λ₁(t, q, p, params, c)
+    l₂ = λ₂(t, q, p, params, c)
+
+    components!(v, i -> dHdpᵢ(i, t, q, p, params) + l₁ * dgᵏdpₗ(c[1], i, t, q, p)
+                                                  + l₂ * dgᵏdpₗ(c[2], i, t, q, p))
     nothing
 end
 
-function guiding_center_3d_f(f, t, q, p, params)
-    f[1] = -dHdq₁(t, q, p, params) - λ₁(t, q, p, params) * dg₁dq₁(t, q, p) - λ₂(t, q, p, params) * dg₂dq₁(t, q, p)
-    f[2] = -dHdq₂(t, q, p, params) - λ₁(t, q, p, params) * dg₁dq₂(t, q, p) - λ₂(t, q, p, params) * dg₂dq₂(t, q, p)
-    f[3] = -dHdq₃(t, q, p, params) - λ₁(t, q, p, params) * dg₁dq₃(t, q, p) - λ₂(t, q, p, params) * dg₂dq₃(t, q, p)
+function guiding_center_3d_f(f, t, q, p, params, c = default_constraint_pair())
+    l₁ = λ₁(t, q, p, params, c)
+    l₂ = λ₂(t, q, p, params, c)
+
+    components!(f, i -> -dHdqᵢ(i, t, q, p, params) - l₁ * dgᵏdqₗ(c[1], i, t, q, p)
+                                                   - l₂ * dgᵏdqₗ(c[2], i, t, q, p))
     nothing
 end
+
 
 """
     hodeproblem(q₀, p₀; kwargs...)
@@ -290,18 +208,29 @@ end
     hodeproblem(ics::NamedTuple; kwargs...)
 
 The constrained canonical guiding centre system as an `HODEProblem` in the position and its
-conjugate momentum.
+conjugate momentum — the Hamilton-Dirac form, with the Lagrange multipliers substituted.
 
 The first form takes the position and momentum directly. The second takes the four-component state
 ``(x, u)`` and recovers the momentum from it through `initial_conditions`; this is the form
 the module constant `qᵢ` is in. The third takes the named tuple that every `initial_conditions_*`
 returns, so `hodeproblem(initial_conditions_barely_passing())` carries that condition's own `μ`.
+
+`constraints` selects which pair of the three constraints is retained; see
+[`constraint_pair`](@ref). It defaults to [`default_constraints`](@ref), which each equilibrium sets
+to a pair that is regular at its own initial condition. Where the pair is singular the multipliers
+are infinite and the problem cannot be integrated at all, so this is not a free choice.
 """
 function hodeproblem(q₀::AbstractVector, p₀::AbstractVector; timespan = DEFAULT_TIMESPAN,
-                     timestep = DEFAULT_TIMESTEP, parameters = default_parameters(), periodic = true)
+                     timestep = DEFAULT_TIMESTEP, parameters = default_parameters(), periodic = true,
+                     constraints = default_constraints())
+    c = constraint_pair(constraints)
+
+    _v(v, t, q, p, params) = guiding_center_3d_v(v, t, q, p, params, c)
+    _f(f, t, q, p, params) = guiding_center_3d_f(f, t, q, p, params, c)
+
     HODEProblem(
-        guiding_center_3d_v,
-        guiding_center_3d_f,
+        _v,
+        _f,
         hamiltonian,
         timespan, timestep, q₀, p₀;
         parameters=parameters,

--- a/src/guiding_center_3d/quadratic_potentials.jl
+++ b/src/guiding_center_3d/quadratic_potentials.jl
@@ -19,10 +19,18 @@ const DEFAULT_TIMESPAN = (0.0, 2.5E4)
 
 initial_conditions_quadratic() = merge(initial_conditions(0.0, [0.3, 0.2, -1.4, 0.3]), (params=(μ=2.5E-3,),))
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(2.5E-3),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+All three pairs are well conditioned in this equilibrium, so this keeps the
+historical choice.
+"""
+default_constraints() = :g31
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/quadratic_potentials.jl
+++ b/src/guiding_center_3d/quadratic_potentials.jl
@@ -27,8 +27,11 @@ default_parameters(::Type{T}=Float64) where {T} = (μ = T(2.5E-3),)
 """
 The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
 
-All three pairs are well conditioned in this equilibrium, so this keeps the
-historical choice.
+All three pairs are regular at the initial condition, and this is the worst conditioned of them:
+`b₁ = 2E-3` gives `λₒ = 0.2`, against 100 for `(g¹, g²)` and 0.3 for `(g², g³)`. It is kept because it
+is the pair the package has always used here and because the numbers in `docs/src/findings.md` were
+measured with it, not because it is the best available — see the conditioning table there, and the open
+item in `TODO.md` about choosing the defaults on conditioning along the orbit.
 """
 default_constraints() = :g31
 

--- a/src/guiding_center_3d/solovev_iter.jl
+++ b/src/guiding_center_3d/solovev_iter.jl
@@ -19,10 +19,18 @@ const DEFAULT_TIMESPAN = (0.0, 1000.0)
 const xᵢ = [7.0 - 1.4, 0.0, 0.0]
 const qᵢ = [from_cartesian(0, xᵢ)..., 2.8166280889939737]
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(4.607782183567846),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ = b_R` vanishes on the midplane, where every initial condition of this
+equilibrium sits, so `(g³, g¹)` is singular there. `(g¹, g²)` divides by `b₃ = b_φ` instead.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")
@@ -33,7 +41,7 @@ include("guiding_center_3d_canonical.jl")
 # three-component state and carried a spurious factor of R that destroys the conservation.
 toroidal_momentum(t, q, p) = p[3]
 
-# include("guiding_center_3d_diagnostics.jl")
+include("guiding_center_3d_diagnostics.jl")
 
 initial_conditions_barely_passing() = merge(initial_conditions(0, [from_cartesian(0, [2.5, 0.0, 0.0])..., 3.425E-1]), (params=(μ=1E-2,),))
 initial_conditions_barely_trapped() = merge(initial_conditions(0, [from_cartesian(0, [2.5, 0.0, 0.0])..., 3.375E-1]), (params=(μ=1E-2,),))

--- a/src/guiding_center_3d/solovev_iter_xpoint.jl
+++ b/src/guiding_center_3d/solovev_iter_xpoint.jl
@@ -19,10 +19,18 @@ const DEFAULT_TIMESPAN = (0.0, 1000.0)
 const xᵢ = [7.0 - 1.4, 0.0, 0.0]
 const qᵢ = [from_cartesian(0, xᵢ)..., 2.8166280889939737]
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(4.607782183567846),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁` is small but non-zero at every initial condition of this
+equilibrium, so the historical pair is still usable.
+"""
+default_constraints() = :g31
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/solovev_symmetric.jl
+++ b/src/guiding_center_3d/solovev_symmetric.jl
@@ -20,10 +20,18 @@ initial_conditions_barely_trapped() = merge(initial_conditions(0, [2.5, 0.0, 0.0
 initial_conditions_deeply_passing() = merge(initial_conditions(0, [2.5, 0.0, 0.0, 5E-1]), (params=(μ=1E-2,),))     # Δt=2.5, nt=25
 initial_conditions_deeply_trapped() = merge(initial_conditions(0, [2.5, 0.0, 0.0, 1E-1]), (params=(μ=1E-2,),))     # Δt=5.0, nt=50
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(1E-2),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+Both `b₁` and `b₃` vanish at the initial conditions of this equilibrium,
+where `b = e₂`, which leaves `(g², g³)` as the only regular pair.
+"""
+default_constraints() = :g23
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/symmetric_quadratic.jl
+++ b/src/guiding_center_3d/symmetric_quadratic.jl
@@ -90,10 +90,18 @@ function f_surface(s, t)
     return q
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(1E-2),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b = e₃` throughout this equilibrium, which leaves `(g¹, g²)` as the
+only regular pair.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/theta_pinch.jl
+++ b/src/guiding_center_3d/theta_pinch.jl
@@ -46,10 +46,17 @@ function f_loop(t)
     return qt
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(2.5E-6),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`B = B₀ e_z`, so `b₁ = b₂ = 0` and `(g¹, g²)` is the only regular pair.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/tokamak_iter_cylindrical.jl
+++ b/src/guiding_center_3d/tokamak_iter_cylindrical.jl
@@ -18,10 +18,18 @@ const DEFAULT_TIMESPAN = (0.0, 1000.0)
 
 const qᵢ = [7.0 - 1.4, 0.0, 0.0, 2.8166280889939737]
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(4.607782183567846),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ = b_R` vanishes on the midplane, where every initial condition of
+this equilibrium sits, so `(g³, g¹)` is singular there. `(g¹, g²)` divides by `b₃ = b_φ` instead.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/tokamak_medium_cartesian.jl
+++ b/src/guiding_center_3d/tokamak_medium_cartesian.jl
@@ -54,10 +54,18 @@ function f_surface(s, t)
     return qt
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(1E-2),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ ≠ 0` at every initial condition of this equilibrium, so the
+historical pair is still usable.
+"""
+default_constraints() = :g31
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/tokamak_medium_cartesian.jl
+++ b/src/guiding_center_3d/tokamak_medium_cartesian.jl
@@ -62,8 +62,14 @@ default_parameters(::Type{T}=Float64) where {T} = (μ = T(1E-2),)
 """
 The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
 
-`b₁ ≠ 0` at every initial condition of this equilibrium, so the
-historical pair is still usable.
+The one equilibrium in the package where no component of `b` vanishes at the initial condition, so all
+three pairs are usable and the three can be compared against each other — which is what
+`test/guiding_center_3d_tests.jl` does with them.
+
+This is the worst conditioned of the three, at `λₒ = -0.15` against `-3.8` for `(g², g³)`, and `b₁`
+falls to 3.5E-4 along the orbit, which is what drives the omitted constraint to 1.4E-6 where the
+retained pair holds 2E-9. It is kept because the measurements in `docs/src/findings.md` were made with
+it; see the open item in `TODO.md`.
 """
 default_constraints() = :g31
 

--- a/src/guiding_center_3d/tokamak_medium_cylindrical.jl
+++ b/src/guiding_center_3d/tokamak_medium_cylindrical.jl
@@ -54,10 +54,18 @@ function f_surface(s, t)
     return qt
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(1E-2),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ = b_R` vanishes on the midplane, where every initial condition of
+this equilibrium sits, so `(g³, g¹)` is singular there. `(g¹, g²)` divides by `b₃ = b_φ` instead.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/tokamak_small_cartesian.jl
+++ b/src/guiding_center_3d/tokamak_small_cartesian.jl
@@ -64,10 +64,19 @@ function f_surface(s, t)
     return qt
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(3.2e-7),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ = B_x` vanishes at the initial conditions of this equilibrium,
+which sit at `y = z = 0`, so `(g³, g¹)` is singular there. `(g², g³)` divides by `b₂`, the toroidal
+component in this chart and the largest of the three.
+"""
+default_constraints() = :g23
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/tokamak_small_cylindrical.jl
+++ b/src/guiding_center_3d/tokamak_small_cylindrical.jl
@@ -64,10 +64,18 @@ function f_surface(s, t)
     return qt
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(2.314593645825811e-6),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ = b_R` vanishes on the midplane, where every initial condition of
+this equilibrium sits, so `(g³, g¹)` is singular there. `(g¹, g²)` divides by `b₃ = b_φ` instead.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/src/guiding_center_3d/tokamak_small_toroidal.jl
+++ b/src/guiding_center_3d/tokamak_small_toroidal.jl
@@ -64,10 +64,18 @@ function f_surface(s, t)
     return qt
 end
 
-export default_parameters
+export default_parameters, default_constraints
 
 "The magnetic moment μ this equilibrium is set up for."
 default_parameters(::Type{T}=Float64) where {T} = (μ = T(2.314593645825811e-6),)
+
+"""
+The constraint pair [`hodeproblem`](@ref) and its siblings use here by default.
+
+`b₁ = b_r` vanishes on the midplane, where every initial condition of
+this equilibrium sits, so `(g³, g¹)` is singular there. `(g¹, g²)` divides by `b₃ = b_φ` instead.
+"""
+default_constraints() = :g12
 
 
 include("guiding_center_3d_equations.jl")

--- a/test/guiding_center_3d_tests.jl
+++ b/test/guiding_center_3d_tests.jl
@@ -77,6 +77,9 @@ end
     test_guiding_center_3d(hodeproblem_canonical(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
     test_guiding_center_3d(hodeproblem_canonical(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+
     # test_guiding_center_3d(iode(initial_conditions_trapped(); timestep = 1E4, timespan = (0, 1E6)))
     # test_guiding_center_3d(iode(initial_conditions_barely_passing()))
     # test_guiding_center_3d(iode(initial_conditions_barely_trapped()))
@@ -97,10 +100,14 @@ end
     using ChargedParticleDynamics.GuidingCenter3d.Dipole3d
     using ..GuidingCenter3dTests
 
-    # The dipole is stiffer than the tokamaks: `hodeproblem_canonical` does not converge at the 0.1
-    # the blocks below use, so both run at the module's own default step of 0.03.
+    # These run at the module's own default step of 0.03 rather than the 0.1 the blocks below use,
+    # because that is where the dipole's constraints stay at 1E-8 rather than 1E-6. The step size is
+    # not what used to stop `hodeproblem_canonical` converging here, though — the constraint pair was.
+    # `Dipole3d` is the one equilibrium whose default pair is chosen on its conditioning along the
+    # orbit rather than at the initial condition; see `default_constraints` in `dipole.jl`.
     test_guiding_center_3d(hodeproblem(initial_conditions_dipole(); timespan=(0.0, 3.0), timestep=0.03))
     test_guiding_center_3d(hodeproblem_canonical(initial_conditions_dipole(); timespan=(0.0, 3.0), timestep=0.03))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_dipole(); timespan=(0.0, 3.0), timestep=0.03))
 
 end
 
@@ -115,6 +122,7 @@ end
     # `dHdqᵢ` on a field where they do not vanish.
     test_guiding_center_3d(hodeproblem(initial_conditions_quadratic(); timespan=(0.0, 1E1), timestep=0.1))
     test_guiding_center_3d(hodeproblem_canonical(initial_conditions_quadratic(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_quadratic(); timespan=(0.0, 1E1), timestep=0.1))
 
 end
 
@@ -141,6 +149,15 @@ end
     test_guiding_center_3d(hodeproblem_canonical(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
     test_guiding_center_3d(hodeproblem_canonical(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+
+    # The one equilibrium where no component of `b` vanishes at the initial condition, so all three
+    # constraint pairs are usable and can be compared against each other; see the "the constraint
+    # formulations agree" block at the end of this file.
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); constraints=:g12, timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); constraints=:g23, timespan=(0.0, 1E1), timestep=0.1))
+
     # test_guiding_center_3d(iode(initial_conditions_barely_passing()))
     # test_guiding_center_3d(iode(initial_conditions_barely_trapped()))
     # test_guiding_center_3d(iode(initial_conditions_deeply_passing()))
@@ -151,158 +168,174 @@ end
 end
 
 
-# @safetestset "Guiding Centre Dynamics in 3D with medium-size Tokamak Equilibrium in Cylindrical Coordinates       " begin
+@safetestset "Guiding Centre Dynamics in 3D with medium-size Tokamak Equilibrium in Cylindrical Coordinates       " begin
 
-#     using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical
-#     using ..GuidingCenter3dTests
+    using ChargedParticleDynamics.GuidingCenter3d.TokamakMediumCylindrical
+    using ..GuidingCenter3dTests
 
-#     # test_guiding_center_3d(ode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_trapped()))
-#     # test_guiding_center_3d(guiding_center_3d_loop_ode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_ode(nx, ny))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     # test_guiding_center_3d(iode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(iode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_trapped()))
-#     # test_guiding_center_3d(guiding_center_3d_loop_iode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_iode(nx, ny))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-# end
+end
 
 
-# @safetestset "Guiding Centre Dynamics in 3D with small-size Tokamak Equilibrium in Cartesian Coordinates          " begin
+@safetestset "Guiding Centre Dynamics in 3D with small-size Tokamak Equilibrium in Cartesian Coordinates          " begin
 
-#     using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian
-#     using ..GuidingCenter3dTests
+    using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCartesian
+    using ..GuidingCenter3dTests
 
-#     # test_guiding_center_3d(ode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_trapped()))
-#     # test_guiding_center_3d(guiding_center_3d_loop_ode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_ode(nx, ny))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     # test_guiding_center_3d(iode(initial_conditions_barely_passing(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_barely_trapped(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_passing(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_trapped(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(guiding_center_3d_loop_iode(nl; timestep = 10., timespan = [0, 1E3]))
-#     # test_guiding_center_3d(guiding_center_3d_surface_iode(nx, ny; timestep = 10., timespan = [0, 1E3]))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-# end
+end
 
 
-# @safetestset "Guiding Centre Dynamics in 3D with small-size Tokamak Equilibrium in Cylindrical Coordinates        " begin
+@safetestset "Guiding Centre Dynamics in 3D with small-size Tokamak Equilibrium in Cylindrical Coordinates        " begin
 
-#     using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCylindrical
-#     using ..GuidingCenter3dTests
+    using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallCylindrical
+    using ..GuidingCenter3dTests
 
-#     # test_guiding_center_3d(ode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_trapped()))
-#     # test_guiding_center_3d(guiding_center_3d_loop_ode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_ode(nx, ny))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     # test_guiding_center_3d(iode(initial_conditions_barely_passing(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_barely_trapped(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_passing(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_trapped(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(guiding_center_3d_loop_iode(nl; timestep = 10., timespan = [0, 1E3]))
-#     # test_guiding_center_3d(guiding_center_3d_surface_iode(nx, ny; timestep = 10., timespan = [0, 1E3]))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-# end
+end
 
 
-# @safetestset "Guiding Centre Dynamics in 3D with small-size Tokamak Equilibrium in Toroidal Coordinates           " begin
+@safetestset "Guiding Centre Dynamics in 3D with small-size Tokamak Equilibrium in Toroidal Coordinates           " begin
 
-#     using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal
-#     using ..GuidingCenter3dTests
+    using ChargedParticleDynamics.GuidingCenter3d.TokamakSmallToroidal
+    using ..GuidingCenter3dTests
 
-#     # test_guiding_center_3d(ode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_trapped()))
-#     # test_guiding_center_3d(guiding_center_3d_loop_ode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_ode(nx, ny))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_canonical(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     # test_guiding_center_3d(iode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(iode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_passing(); timestep = 10., timespan = (0, 1E3)))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_trapped()))
-#     # test_guiding_center_3d(guiding_center_3d_loop_iode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_iode(nx, ny))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-# end
+end
 
 
-# @safetestset "Guiding Centre Dynamics in 3D with symmetric Solov'ev Equilibrium                                   " begin
+@safetestset "Guiding Centre Dynamics in 3D with symmetric Solov'ev Equilibrium                                   " begin
 
-#     using ChargedParticleDynamics.GuidingCenter3d.SolovevSymmetricField
-#     using ..GuidingCenter3dTests
+    using ChargedParticleDynamics.GuidingCenter3d.SolovevSymmetricField
+    using ..GuidingCenter3dTests
 
-#     # test_guiding_center_3d(ode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(ode(initial_conditions_deeply_trapped()))
+    # The only equilibrium for which two of the three constraint pairs are singular at once: `b = e₂`
+    # at these initial conditions, so both `(g³, g¹)` and `(g¹, g²)` divide by zero and only the
+    # `(g², g³)` this module defaults to survives. See `default_constraints` in `solovev_symmetric.jl`.
+    #
+    # Also the one block that cannot be run over the module's own `DEFAULT_TIMESPAN`. This is the
+    # stiffest equilibrium in the package — `‖ϑ‖ ≈ 256`, an order of magnitude above the ITER-like
+    # Solov'ev equilibria — and the constraint drift grows fast enough that Newton meets a NaN a few
+    # hundred steps in. A hundred steps, the same workload as the blocks above, is well inside that.
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_passing()))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_barely_trapped()))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_passing()))
-#     test_guiding_center_3d(hodeproblem(initial_conditions_deeply_trapped()))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_barely_passing(); timespan=(0.0, 1E1), timestep=0.1))
+    test_guiding_center_3d(hodeproblem_compact(initial_conditions_deeply_trapped(); timespan=(0.0, 1E1), timestep=0.1))
 
-#     # test_guiding_center_3d(iode(initial_conditions_barely_passing()))
-#     # test_guiding_center_3d(iode(initial_conditions_barely_trapped()))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_passing()))
-#     # test_guiding_center_3d(iode(initial_conditions_deeply_trapped()))
+    # `hodeproblem_canonical` is *not* exercised here. It starts fine — the pair is well conditioned,
+    # `λₒ ≈ -228` and never falls below -173 along the orbit — but the ∂λ/∂q, ∂λ/∂p terms it adds
+    # amplify the constraint drift enough that Newton hits a NaN after some thirty steps. That is a
+    # property of the canonicalised formulation on this equilibrium, not of the constraint pair: the
+    # same orbit runs to completion with `hodeproblem` and `hodeproblem_compact`. Section 2 of
+    # `scripts/study_guiding_center_3d_conditioning.jl` shows the same thing quantitatively.
 
-# end
-
-
-# @safetestset "Guiding Centre Dynamics in 3D with symmetric Equlibrium                                             " begin
-
-#     using ChargedParticleDynamics.GuidingCenter3d.SymmetricField
-#     using ..GuidingCenter3dTests
-
-#     # test_guiding_center_3d(guiding_center_3d_loop_ode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_ode(nx, ny))
-
-#     # test_guiding_center_3d(guiding_center_3d_loop_iode(nl))
-#     # test_guiding_center_3d(guiding_center_3d_surface_iode(nx, ny))
-
-# end
+end
 
 
-# @safetestset "Guiding Centre Dynamics in 3D with Theta Pinch Equilibrium                                          " begin
+# `SymmetricField` and `ThetaPinchField` have no integration test block. Both are Poincaré-invariant
+# fixtures: they ship `f_loop`/`f_surface` rather than `initial_conditions_*`, and the blocks that
+# used to stand here called `guiding_center_3d_loop_ode` and `guiding_center_3d_surface_ode`, which
+# this package no longer defines. Their constraints are exercised instead by the derivative tests in
+# `test/structure_tests.jl`, which reach every module. Note that `b = e₃` in both, so `(g¹, g²)` is
+# the only pair either of them can use.
 
-#     using ChargedParticleDynamics.GuidingCenter3d.ThetaPinchField
-#     using ..GuidingCenter3dTests
 
-#     # test_guiding_center_3d(guiding_center_3d_loop_ode(nl))
+@safetestset "Guiding Centre Dynamics in 3D: the constraint formulations agree                                    " begin
 
-#     # test_guiding_center_3d(guiding_center_3d_loop_iode(nl))
+    using ChargedParticleDynamics.GuidingCenter3d
+    using GeometricIntegrators
+    using LinearAlgebra
+    using Test
+    using ..GuidingCenter3dTests
 
-# end
+    # The substantive check on the three constraint pairs and the three formulations: where they are
+    # all well conditioned they describe the same constrained system and must agree to the accuracy of
+    # the nonlinear solve. `TokamakMediumCartesian` is the one equilibrium in the package for which no
+    # component of `b` vanishes at the initial condition, so all three pairs are usable there at once.
+    mx(ds) = maximum(abs(ds[i]) for i in eachindex(ds))
+
+    M = GuidingCenter3d.TokamakMediumCartesian
+    ic = M.initial_conditions_barely_passing()
+    workload = (timespan = (0.0, 1E1), timestep = 0.1)
+
+    problems = ((M.hodeproblem(ic; constraints = :g31, workload...)),
+                (M.hodeproblem(ic; constraints = :g12, workload...)),
+                (M.hodeproblem(ic; constraints = :g23, workload...)),
+                (M.hodeproblem_canonical(ic; workload...)),
+                (M.hodeproblem_compact(ic; workload...)),
+                (M.hodeproblem_compact(ic; constraints = :g31, workload...)))
+
+    # `options` is not exported by the helper module — the blocks above reach it through
+    # `test_guiding_center_3d` rather than by name — so it is qualified here.
+    solutions = [integrate(p, PartitionedGauss(2); initialguess = MidpointExtrapolation(5),
+                           GuidingCenter3dTests.options...)
+                 for p in problems]
+
+    reference = vcat(solutions[1].q[end], solutions[1].p[end])
+
+    for (problem, solution) in zip(problems, solutions)
+        y = vcat(solution.q[end], solution.p[end])
+        @test all(isfinite, y)
+        @test norm(y - reference) / norm(reference) < 1E-7
+
+        # All three constraints vanish along the flow, whichever pair the problem retained.
+        c = M.compute_constraints(solution)
+        @test mx(c.g₁) < 1E-7
+        @test mx(c.g₂) < 1E-7
+        @test mx(c.g₃) < 1E-7
+
+        _, e = M.compute_energy_error(solution.t, solution.q, solution.p, parameters(problem))
+        @test mx(e) < 1E-7
+    end
+
+    # An unknown pair is a typo, not a silent fallback to the default.
+    @test_throws MethodError M.hodeproblem(ic; constraints = :g13, workload...)
+
+    # `:parallel` is the pair-independent regularisation of the compact form and means nothing for the
+    # other two, which must say so rather than quietly picking something.
+    @test_throws MethodError M.hodeproblem(ic; constraints = :parallel, workload...)
+    @test_throws MethodError M.hodeproblem_canonical(ic; constraints = :parallel, workload...)
+end

--- a/test/structure_tests.jl
+++ b/test/structure_tests.jl
@@ -101,7 +101,7 @@ end
         :GuidingCenter4d   => ["odeproblem", "iodeproblem",
                                "lodeproblem", "iodeproblem_λ",
                                "iodeproblem_dg", "lodeproblem_formal_lagrangian"],
-        :GuidingCenter3d   => ["hodeproblem", "hodeproblem_canonical"],
+        :GuidingCenter3d   => ["hodeproblem", "hodeproblem_canonical", "hodeproblem_compact"],
         :ChargedParticle3d => ["odeproblem", "iodeproblem",
                                "lodeproblem", "podeproblem"],
         :PauliParticle3d   => ["podeproblem", "hodeproblem",
@@ -271,6 +271,140 @@ end
 end
 
 
+@safetestset "3D guiding centre: constraint derivatives match finite differences                                  " begin
+    using ChargedParticleDynamics.GuidingCenter3d
+    using ..StructureTestUtils
+    using Test
+
+    # The three constraints and every one of their first and second derivatives come from one indexed
+    # definition each in `guiding_center_3d_constraints.jl`, so a sign or an index that is wrong is
+    # wrong for all three pairs at once — and only two of the three used to exist at all. This checks
+    # each of them against a central difference of the derivative one order below, for every index
+    # combination, in three charts.
+    for M in (GuidingCenter3d.SolovevIterXpoint,        # cylindrical
+              GuidingCenter3d.TokamakMediumCartesian,   # cartesian
+              GuidingCenter3d.TokamakSmallToroidal)     # toroidal
+        ic = M.initial_conditions_barely_passing()
+        t, q, p = 0.0, ic.q, ic.p
+
+        # A central difference at h = 1e-6 of a quantity of size s carries about `eps * s / h ≈
+        # 2E-10 s` of round-off, and several entries of these Hessians vanish exactly, so the
+        # comparison needs an absolute floor scaled to the problem rather than a fixed one. `s` is
+        # bounded by the momentum, which runs from 1E-3 on the toroidal tokamak to 15 on ITER.
+        atol = 1e-8 * max(1.0, maximum(abs, p))
+
+        for ki in 1:3, li in 1:3
+            k, l = Val(ki), Val(li)
+
+            # ∂gᵏ/∂qₗ and ∂gᵏ/∂pₗ against a difference of gᵏ itself
+            @test isapprox(M.dgᵏdqₗ(k, l, t, q, p),
+                           central_difference(x -> M.gᵏ(k, t, x, p), q, li); rtol = 1e-5, atol = atol)
+            @test isapprox(M.dgᵏdpₗ(k, l, t, q, p),
+                           central_difference(y -> M.gᵏ(k, t, q, y), p, li); rtol = 1e-5, atol = atol)
+
+            for mi in 1:3
+                m = Val(mi)
+
+                # ∂²gᵏ/∂qₗ∂qₘ has to reproduce a difference of ∂gᵏ/∂qₗ, and to be symmetric in the
+                # two indices.
+                @test isapprox(M.d²gᵏdqₗdqₘ(k, l, m, t, q, p),
+                               central_difference(x -> M.dgᵏdqₗ(k, l, t, x, p), q, mi);
+                               rtol = 1e-4, atol = atol)
+                @test isapprox(M.d²gᵏdqₗdqₘ(k, l, m, t, q, p),
+                               M.d²gᵏdqₗdqₘ(k, m, l, t, q, p); rtol = 1e-12, atol = 1e-14)
+
+                # ∂²gᵏ/∂qₗ∂pₘ likewise, differentiated from either side
+                @test isapprox(M.d²gᵏdqₗdpₘ(k, l, m, t, q, p),
+                               central_difference(y -> M.dgᵏdqₗ(k, l, t, q, y), p, mi);
+                               rtol = 1e-4, atol = atol)
+                @test isapprox(M.d²gᵏdqₗdpₘ(k, l, m, t, q, p),
+                               central_difference(x -> M.dgᵏdpₗ(k, m, t, x, p), q, li);
+                               rtol = 1e-4, atol = atol)
+            end
+        end
+
+        # `{cᵢ, cⱼ}(m) = bₘ D` with the same `D` for all three `m`. This is what lets the compact form
+        # replace the singular factor `bₘ / {cᵢ, cⱼ}` by `1/D`, and it is the one step of that
+        # derivation that is not pure algebra — it has to hold in every chart, which is exactly what
+        # cannot be read off the paper, since Eq. (29) is written in cartesian coordinates. Checked
+        # here in all three chart types.
+        D = M.compact_denominator(t, q, p)
+        for m in (Val(1), Val(2), Val(3))
+            b = M.bᵢ(m, t, q)
+            iszero(b) && continue
+            @test M.bracket_cc(m, t, q, p) / b ≈ D rtol = 1e-10
+        end
+
+        # b·(b×v) = 0 identically, which in the paper's labelling reads b₁g² - b₂g¹ + b₃g³ = 0. It is
+        # the identity the compact form uses to remove the singular factor, and it must hold whether
+        # or not the constraints themselves do.
+        for y in (p, p .+ 0.1)
+            @test isapprox(M.b₁(t, q) * M.g₂(t, q, y) - M.b₂(t, q) * M.g₁(t, q, y) +
+                           M.b₃(t, q) * M.g₃(t, q, y), 0.0; atol = 1e-12)
+        end
+    end
+end
+
+
+@safetestset "3D guiding centre: the compact form reproduces the paper's Eq. (29)                                 " begin
+    using ChargedParticleDynamics.GuidingCenter3d
+    using LinearAlgebra
+    using Test
+
+    # `guiding_center_3d_compact.jl` does not port Eq. (29) of Li, Zhang & Liu — that equation is
+    # written with cartesian vector identities and `H = ½Σ(pᵢ-Aᵢ)²`, and eight of the thirteen
+    # equilibria here are curvilinear — but derives an equivalent from the model's own objects. This
+    # pins that derivation against the paper by spelling Eq. (29) out directly from the injected field
+    # functions, which is only possible in the cartesian charts, where the metric is the identity.
+    for M in (GuidingCenter3d.Dipole3d, GuidingCenter3d.QuadraticPotentials3d,
+              GuidingCenter3d.TokamakMediumCartesian)
+        ic = isdefined(M, :initial_conditions_dipole) ? M.initial_conditions_dipole() :
+             isdefined(M, :initial_conditions_quadratic) ? M.initial_conditions_quadratic() :
+             M.initial_conditions_barely_passing()
+        t, q, p, par = 0.0, ic.q, ic.p, ic.params
+
+        @test (M.g¹¹(t, q), M.g²²(t, q), M.g³³(t, q)) == (1, 1, 1)
+
+        b = [M.b₁(t, q), M.b₂(t, q), M.b₃(t, q)]
+        A = [M.A₁(t, q), M.A₂(t, q), M.A₃(t, q)]
+        v = p .- A
+        db = [M.db₁dx₁(t, q) M.db₁dx₂(t, q) M.db₁dx₃(t, q)
+              M.db₂dx₁(t, q) M.db₂dx₂(t, q) M.db₂dx₃(t, q)
+              M.db₃dx₁(t, q) M.db₃dx₂(t, q) M.db₃dx₃(t, q)]
+        dA = [M.dA₁dx₁(t, q) M.dA₁dx₂(t, q) M.dA₁dx₃(t, q)
+              M.dA₂dx₁(t, q) M.dA₂dx₂(t, q) M.dA₂dx₃(t, q)
+              M.dA₃dx₁(t, q) M.dA₃dx₂(t, q) M.dA₃dx₃(t, q)]
+        ∇B = [M.dBdx₁(t, q), M.dBdx₂(t, q), M.dBdx₃(t, q)]
+        # `E = -∇Φ`: `hamiltonian` carries `+φ` while `dHdqᵢ` subtracts `Eᵢ`.
+        ∇Φ = -[M.E₁(t, q), M.E₂(t, q), M.E₃(t, q)]
+        ∇xb = [db[3, 2] - db[2, 3], db[1, 3] - db[3, 1], db[2, 1] - db[1, 2]]
+
+        # The scalar denominator of Eq. (24), which `compact_denominator` reaches without ever
+        # dividing by a component of b.
+        D = M.B(t, q) + dot(v, ∇xb)
+        @test M.compact_denominator(t, q, p) ≈ D rtol = 1e-12
+
+        ξ = cross(v, db * v)                                                             # Eq. (26)
+        Ẋ = v .+ (ξ .+ par.μ .* cross(b, ∇B) .+ cross(b, ∇Φ)) ./ D                       # Eq. (29a)
+        u = (p[3] - A[3]) / b[3]                                                         # the (g¹,g²) pair
+        ṗ = -par.μ .* ∇B .- ∇Φ .+ dA' * Ẋ .+
+            db' * ((u .* ξ .+ cross(v, par.μ .* ∇B .+ ∇Φ)) ./ D)                         # Eq. (29b)
+
+        for constraints in (:g12, :parallel)
+            # The two branches differ only in how they evaluate the parallel velocity and the
+            # denominator, which agree on the constraint manifold the initial condition sits on.
+            m = M.compact_index(constraints)
+            v̄ = zeros(3); f̄ = zeros(3)
+            M.guiding_center_3d_compact_v(v̄, t, q, p, par, m)
+            M.guiding_center_3d_compact_f(f̄, t, q, p, par, m)
+
+            @test isapprox(v̄, Ẋ; rtol = 1e-10)
+            @test isapprox(f̄, ṗ; rtol = 1e-10, atol = 1e-14)
+        end
+    end
+end
+
+
 @safetestset "4D guiding centre: ḡ matches finite differences of the one-form gradient                            " begin
     using ChargedParticleDynamics.GuidingCenter4d
     using ..StructureTestUtils
@@ -420,9 +554,35 @@ end
         _, eerr = M.compute_energy_error(sol)
         @test mx(eerr) < 1e-8
 
+        # All three components of `v × b` vanish along the flow, not only the two the problem's
+        # constraint pair retains, so all three are asserted on — but not to the same bound. The
+        # identity `b₁g² - b₂g¹ + b₃g³ = 0` holds pointwise, so it determines the omitted constraint
+        # from the retained two divided by `bₘ`, the component of `b` the pair's multipliers divide by:
+        #
+        #     |g_omitted| ≲ max |g_retained| / min|bₘ|
+        #
+        # with the minimum taken along the orbit, not at the initial condition. Both equilibria here
+        # cross the surface where `bₘ` is small — `min|b₁|` is 1E-5 on the ITER Solov'ev X-point and
+        # 3.5E-4 on the medium tokamak — and the omitted `g²` duly comes out three orders of magnitude
+        # larger than the retained pair on the latter. It is the sharpest argument for picking the pair
+        # whose `bₘ` is largest, and the reason `compute_constraints` reports all three.
         c = M.compute_constraints(sol)
-        @test mx(c.g₁) < 1e-8
-        @test mx(c.g₂) < 1e-8
+        gs = (c.g₁, c.g₂, c.g₃)
+        bs = (M.b₁, M.b₂, M.b₃)
+
+        retained = map(v -> only(typeof(v).parameters), M.constraint_pair(M.default_constraints()))
+        omitted = only(setdiff(1:3, retained))
+
+        # `compact_index` is the component of `b` the pair divides by, which is not `omitted`: the
+        # labelling of the `gᵏ` is not the antisymmetric one, so `(g³, g¹)` omits `g²` but divides by
+        # `b₁`.
+        m = only(typeof(M.compact_index(M.default_constraints())).parameters)
+        bmin = minimum(abs(bs[m](sol.t[i], sol.q[i])) for i in eachindex(sol.t))
+
+        for k in retained
+            @test mx(gs[k]) < 1e-8
+        end
+        @test mx(gs[omitted]) < 1e-8 / bmin
 
         if isdefined(M, :toroidal_momentum)
             _, perr = M.compute_toroidal_momentum_error(sol)

--- a/test/structure_tests.jl
+++ b/test/structure_tests.jl
@@ -346,6 +346,47 @@ end
 end
 
 
+@safetestset "3D guiding centre: multiplier derivatives match finite differences                                  " begin
+    using ChargedParticleDynamics.GuidingCenter3d
+    using ..StructureTestUtils
+    using Test
+
+    # `∂λ/∂q` and `∂λ/∂p` are the only *composed* derivatives in the model — everything else is read
+    # straight off the injected field functions — and they are what separates `hodeproblem_canonical`
+    # from `hodeproblem`. `dλ₂` carried the `∂λₒ` term with the wrong sign, which this catches.
+    #
+    # The test point has to sit *off* the constraint manifold. In the right-hand side both `∂λ/∂q g`
+    # terms are multiplied by a constraint, so at the shipped initial condition the sign of the `∂λₒ`
+    # term is invisible: `λ₁` and `λ₂` themselves are still finite and correct there, and only their
+    # derivatives are wrong. Displacing `q` breaks `v × b = 0` and makes the term measurable.
+    for M in (GuidingCenter3d.SolovevIterXpoint,        # cylindrical
+              GuidingCenter3d.TokamakMediumCartesian,   # cartesian
+              GuidingCenter3d.TokamakSmallToroidal)     # toroidal
+        ic = M.initial_conditions_barely_passing()
+        t, p, par = 0.0, ic.p, ic.params
+        q = ic.q .+ 0.01 .* [1.0, 2.0, 3.0]
+        c = M.constraint_pair(M.default_constraints())
+
+        # Same reasoning as the constraint block above: a central difference at h = 1e-6 carries about
+        # `eps * s / h` of round-off, and the multipliers run over several orders of magnitude between
+        # these equilibria, so the floor is scaled to the problem rather than fixed.
+        atol = 1e-8 * max(1.0, maximum(abs, p))
+
+        for (λ, dλdq, dλdp) in ((M.λ₁, M.dλ₁dqⱼ, M.dλ₁dpⱼ), (M.λ₂, M.dλ₂dqⱼ, M.dλ₂dpⱼ))
+            for ji in 1:3
+                j = Val(ji)
+                @test isapprox(dλdq(j, t, q, p, par, c),
+                               central_difference(x -> λ(t, x, p, par, c), q, ji);
+                               rtol = 1e-5, atol = atol)
+                @test isapprox(dλdp(j, t, q, p, par, c),
+                               central_difference(y -> λ(t, q, y, par, c), p, ji);
+                               rtol = 1e-5, atol = atol)
+            end
+        end
+    end
+end
+
+
 @safetestset "3D guiding centre: the compact form reproduces the paper's Eq. (29)                                 " begin
     using ChargedParticleDynamics.GuidingCenter3d
     using LinearAlgebra
@@ -570,19 +611,33 @@ end
         gs = (c.g₁, c.g₂, c.g₃)
         bs = (M.b₁, M.b₂, M.b₃)
 
-        retained = map(v -> only(typeof(v).parameters), M.constraint_pair(M.default_constraints()))
+        retained = map(M.unval, M.constraint_pair(M.default_constraints()))
         omitted = only(setdiff(1:3, retained))
 
         # `compact_index` is the component of `b` the pair divides by, which is not `omitted`: the
         # labelling of the `gᵏ` is not the antisymmetric one, so `(g³, g¹)` omits `g²` but divides by
         # `b₁`.
-        m = only(typeof(M.compact_index(M.default_constraints())).parameters)
+        m = M.unval(M.compact_index(M.default_constraints()))
         bmin = minimum(abs(bs[m](sol.t[i], sol.q[i])) for i in eachindex(sol.t))
 
         for k in retained
             @test mx(gs[k]) < 1e-8
         end
-        @test mx(gs[omitted]) < 1e-8 / bmin
+
+        # The bound is anchored to what the retained pair actually achieved rather than to the 1E-8 it
+        # is merely required to stay under. Dividing the requirement by `bmin` gives 9E-4 on the ITER
+        # Solov'ev X-point against an observed 9E-13 — nine orders of slack, which asserts nothing.
+        # Anchoring closes that to five: the retained pair does 1.5E-13 there, five orders better than
+        # required.
+        #
+        # The factor is for the relation above being an inequality with no constant attached. Measured,
+        # the two sides are within 0.3 on the medium tokamak and 7E-5 on the X-point, so 10 leaves the
+        # tighter of the two about 35× of headroom — enough for a solver or platform difference, little
+        # enough that a real regression in the omitted constraint trips it. The floor is for the `:g12`
+        # equilibria, where `bₘ` is the *large* component of `b` and the omitted constraint comes out
+        # better conserved than the retained pair, so the ratio bound goes below round-off.
+        retained_max = maximum(mx(gs[k]) for k in retained)
+        @test mx(gs[omitted]) < max(1e-12, 10 * retained_max / bmin)
 
         if isdefined(M, :toroidal_momentum)
             _, perr = M.compute_toroidal_momentum_error(sol)


### PR DESCRIPTION
The constrained canonical formulation of Li, Zhang & Liu imposes two of the three independent components of `v × b = 0` as constraints. Only one pair was implemented, taken from an *earlier version* of the paper: `(g³, g¹)`, whose Lagrange multipliers divide by `b₁`. That vanishes on the midplane of an axisymmetric equilibrium, which is where seven of the eleven equilibria that ship an initial condition sit — so those could not be integrated at all, which is why ~150 lines of `test/guiding_center_3d_tests.jl` were commented out.

This adds the missing variants, the paper's compact form, and the measurements. Closes the *Add the remaining constraint formulations to the 3D guiding centre model* item in `TODO.md`.

## The three constraint pairs

`constraints = :g31 | :g12 | :g23` on `hodeproblem` and `hodeproblem_canonical`, resolved once in the constructor to `Val`-based dispatch so the right-hand side stays specialised — no run-time adaptivity. Each equilibrium declares its own `default_constraints`.

| `constraints` | pair | `{g₁,g₂}` | singular where |
|---|---|---|---|
| `:g31` | `(g³, g¹)` | `+b₁ [ … ]` | `b₁ = 0` |
| `:g12` | `(g¹, g²)` | `+b₃ [ … ]` | `b₃ = 0` |
| `:g23` | `(g², g³)` | `-b₂ [ … ]` | `b₂ = 0` |

`SolovevSymmetricField` is why all three were needed rather than two: `b = e₂` there, so `b₁` and `b₃` vanish together and only `(g², g³)` survives.

The sign is per pair, not uniform — `(g², g³)` is the one whose ordering reverses the cycle of the antisymmetric labelling. Nothing turns on it, since reversing a pair flips `λₒ` and both multipliers together, but the unsigned `bₘ[…]` this originally documented contradicted the package's own tabulated values, where `λₒ(:g23)` and `b₂` come out with opposite signs throughout.

**The three constraints are the components of `b × v`**, so they are one indexed family and so are their derivatives. Writing them once against a generic index pair in the new `guiding_center_3d_constraints.jl` shrank `guiding_center_3d_canonical.jl` from 722 lines to 361 instead of tripling it — this is the `Val`-based restructuring the TODO settled on. It also made the Hamilton-Dirac right-hand side **2.7× faster**: the old code evaluated `λ₁` and `λ₂` once per component, so both multipliers and the six bracket terms behind them were computed three times per call.

## The compact form, Eq. (29)

`hodeproblem_compact`. Eq. (29) as printed uses cartesian vector identities and `H = ½Σ(pᵢ-Aᵢ)²`, whereas eight of the thirteen equilibria here are curvilinear — so it is **derived coordinate-generally from the model's own objects rather than ported**. The derivation is at the top of `guiding_center_3d_compact.jl` and written up in the manual. Two results are departures from the paper, and are flagged as such:

* **It is independent of the constraint pair.** Eq. (29) depends on the pair only through the parallel velocity, `(pₘ-Aₘ)/bₘ` in three spellings; using `u = b·v` makes the dependence disappear.
* **The literal Eq. (29) is still singular.** `(pₘ-Aₘ)/bₘ` is `0/0` exactly where the pair was singular, so the `νⱼ`/`ωⱼ` terms are not the only obstruction. `:parallel`, the default, removes it.

Passing a pair symbol instead ties the right-hand side to that pair in **two** places, and only one of them is the paper's. The multiplier scale is taken from that pair's own bracket, `bₘ/{cᵢ,cⱼ}(m)`, whereas the paper evaluates it from `D` written out as `|B| + (p-A)·(∇×b)`, which is regular — so that denominator is a choice made here, and is what makes the pair variants the cheapest of the three formulations (three bracket terms rather than the nine `D` averages). Both denominators vanish on the same surface, so it changes nothing about *where* the variant is singular, and the code is unchanged; the docs now say which is which rather than calling it a literal transcription.

`compact_denominator`'s denominator cannot vanish because the metric is positive definite and `Σᵢ gⁱⁱ bᵢ bᵢ = 1` — not because `Σᵢ bᵢ bᵢ = 1`, which is what it originally claimed. The `bᵢ` are covariant, and that sum is 6.25 on `SolovevIterXpoint` and 1.11 on the toroidal tokamak. `D` is unaffected, being a weighted mean and exact for any positive weights, but the old justification failed precisely in the curvilinear charts the derivation was redone for.

## A sign error in `∂λ₂`, found in review

`dλ₂dqⱼ` and `dλ₂dpⱼ` carried the term proportional to `∂{g₁,g₂}` with the wrong sign. Both multipliers are a bracket over `λₒ = {g₁,g₂}`, so both derivatives carry `-λ ∂λₒ/λₒ` whatever the sign of the numerator; `λ₁` had it, `λ₂` had the `+` the quotient rule gives before the minus of `-{g₁,H}` is folded back in. **Pre-existing on `main`** — the rewrite in this PR reproduced it faithfully.

Only `hodeproblem_canonical` uses these, and only multiplied by a constraint, so the error vanished on the constraint manifold. That is why the canonicalised form still agreed with `hodeproblem` to 1e-8 and why nothing caught it. What it cost was accuracy and solver work:

| | before | after |
|---|---|---|
| `TokamakMediumCartesian`, `\|ΔH/H\|` over 100 steps | 7.66e-9 | 2.20e-9 |
| `Dipole3d` canonical, Newton iterations/stage | 3.8 (peak 50) | 2.6 (peak 9) |
| `Dipole3d` canonical, cost vs Hamilton-Dirac | 29.1× | 18.8× |

The right-hand side costs the same either way; the whole difference is the solve. The affected numbers in `findings.md` are re-measured, including `Dipole3d` `:g31` at `t = 30`, which no longer meets a NaN but returns a destroyed trajectory instead.

**The comparisons between the three formulations stand.** The canonicalised form is still the weakest, and `SolovevSymmetricField` still cannot complete an orbit under it, still between thirty and forty steps in. What did not stand is *"two to three orders of magnitude worse conservation"*: measured across all eleven, its energy error runs from slightly **better** than the Hamilton-Dirac form on `TokamakSmallCartesian` to 292× worse, and its constraint error to five orders. That is now stated as a worst case with the spread beside it.

The multiplier derivatives were the only *composed* derivatives in the model without a finite-difference test — everything else is read straight off the injected field functions. There is one now, on all four of them in three charts. It has to evaluate off the constraint manifold: on it either sign passes, which is the whole reason this survived.

## Verification

* All six variants agree to **6e-9** on `TokamakMediumCartesian`, the one equilibrium where all three pairs are regular at once.
* Every `dgᵏ` and `d²gᵏ` against central differences, for all three `k` and every index combination, in cartesian, cylindrical and toroidal charts.
* Every `∂λ₁/∂q`, `∂λ₁/∂p`, `∂λ₂/∂q`, `∂λ₂/∂p` likewise, at a point displaced off the constraint manifold.
* `{cᵢ,cⱼ}(m)/bₘ` is `m`-independent to machine precision in all three chart types — the one step of the compact-form derivation that cannot be read off the cartesian paper.
* Eq. (29) spelled out directly from the injected field functions on the three cartesian equilibria, including the one with a non-zero electrostatic potential, matched to round-off for both the `:parallel` and the pair-dependent variant.
* Five re-enabled test blocks: **nine equilibria integrate, up from four.** The two not re-enabled (`SymmetricField`, `ThetaPinchField`) called loop/surface constructors this package no longer defines and had no integration content; a note replaces them.

Full suite green, docs build clean, suppressed-solver-warning count 1580 → 1578 (measured against the pre-fix tree, not assumed). `scripts/guiding_center_3d.jl` and the ITER example page no longer need their `sqrt(eps())` midplane displacement. The 3D test file goes from four integration blocks to ten, and from roughly four minutes to ten in CI.

## Benchmark

Per step, Hamilton-Dirac as unity, across all eleven equilibria:

| formulation | relative cost |
|---|---|
| compact, pair-dependent | 0.86 – 0.95 |
| Hamilton-Dirac | 1 |
| compact, `:parallel` | 1.21 – 1.44 |
| canonicalised | 8.9 – 18.8 |

The three pairs cost the same as each other, so the pair should be chosen on conditioning alone. The canonicalised row read 8.9 – 29.6 before the `∂λ₂` fix, whose effect there is entirely on the Newton solve.

## Two things worth a reviewer's attention

1. **`Dipole3d`'s default changed on conditioning, not regularity.** All three pairs are regular at its initial condition, but the orbit takes `b₁` and `b₂` through zero: the historical pair holds the constraints to 1e-3 and destroys the trajectory by `t = 30` (`|ΔH/H| = 2e3`), where `:g12` holds 2e-8 out to `t = 300`. The other ten defaults are still chosen on regularity alone — recorded as open in `TODO.md`, since tightening them moves numbers `findings.md` tabulates. `QuadraticPotentials3d` and `TokamakMediumCartesian` in particular default to the *worst* conditioned of their three regular pairs; their docstrings now say so rather than implying the choice was free.
2. **`hodeproblem_canonical` is the weak formulation.** 9–19× the cost, up to two or three orders of magnitude worse energy conservation and four or five worse constraint conservation at these step sizes, and the only one that cannot complete an orbit on `SolovevSymmetricField`. Not a regression — it failed there before too, on the singular pair — but now visible and documented, with the spread stated rather than only the worst case.

**Behaviour changes to note:**

* `compute_constraints` returns three series where it returned two, and `g₁`/`g₂` in the equilibrium modules now mean the paper's `g¹`/`g²` rather than the two members of the hard-coded pair, which were `g³` and `g¹`. All three vanish along the flow either way. The omitted one is reported because it carries the retained pair's drift amplified by `1/bₘ` — a factor of 800 over a thousand steps on `TokamakMediumCartesian` — and is invisible otherwise.
* The short forms `λₒ(t,q,p)`, `λ₁(t,q,p,params)` and `λ₂(t,q,p,params)` take the pair as a trailing argument and default it to each equilibrium's own `default_constraints()`. For the eight modules whose default is no longer `(g³,g¹)` they therefore return the multipliers of a different pair than before; pass `constraint_pair(:g31)` for the old quantity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
