### PR TITLE
Require ElectromagneticFields 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+`ElectromagneticFields` 0.8.0 is a breaking release whose break does not reach this package: it
+moves plotting from Plots.jl recipes to a Makie package extension, and nothing here ever used a
+recipe. Results are unchanged. One figure changes, for a reason of this package's own.
+
+### Changed
+
+- **`ElectromagneticFields` 0.8.0 is now required**, up from 0.7.1, in the root project and in the
+  `docs/` and `scripts/` environments. (`test/` still carries no bound of its own — it reaches the
+  suite through this package.) The bound is a single minor rather than `"0.7.1, 0.8"` so that the
+  allocation and timing figures in `docs/src/findings.md` mean one thing.
+
+  Three parts of the release could have reached this package, and none does:
+
+  - The **plotting break** is invisible here. The twelve `RecipesBase.@recipe` definitions upstream
+    are gone, replaced by an `ElectromagneticFieldsMakieExt` extension and two new exported names,
+    `plot_equilibrium` and `plot_equilibrium!`. There is not one use of Plots.jl or of an upstream
+    recipe anywhere in `src/`, `ext/`, `test/`, `docs/` or `scripts/` — all plotting here is
+    home-grown Makie in `ChargedParticlePlots` — and neither new name collides with the exports of
+    `src/Plots.jl`. Upstream now carries the same `Makie = "0.24"` bound this package does, so the
+    two extensions resolve together.
+  - The rest of the **exported API is unchanged**: those two names are the only additions, nothing
+    was removed or renamed. `code`, `crossproduct`, every `@code*` macro, every equilibrium
+    submodule and the whole injected namespace this package reads — `rangemin`, `rangemax`,
+    `orientation`, `from_cartesian`, `A₁₋₃`, `b₁₋₃`, `b⃗`, `g₁₁₋₃₃`, `ḡ`, `DF̄`, `J`, `aₚ`/`bₚ`/`cₚ`
+    — keep their names and their `(t, ξ₁, ξ₂, ξ₃)` / `(t, ξ)` signatures.
+  - The one change to the **generated code** is value-preserving. A component whose body does not
+    mention the coordinates is now wrapped as `oftype(float(ξ₁), …)`, so the structurally constant
+    entries take the coordinate's float type instead of the `Int` literal SymEngine emitted. That
+    stops `g` and `DF` promoting at runtime — upstream measures 976 and 1072 bytes per call down to
+    the 144 the 3×3 matrix actually is — and every recorded number in the test suite is unmoved.
+    `orientation()` is interpolated as a literal rather than emitted from a symbolic expression, so
+    it is not wrapped and keeps returning an `Int`.
+
 ### Fixed
 
 - **`plot_fieldlines` contours `ψ = A₃`, not `A₃ / R`.** In the `(R, Z, φ)` chart the flux function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+- **`plot_fieldlines` contours `ψ = A₃`, not `A₃ / R`.** In the `(R, Z, φ)` chart the flux function
+  is the *covariant* toroidal component, which the field code injects as `A₃ = R A_φ = ψ`; it is
+  `B · ∇A₃` that vanishes, while `B · ∇(A₃/R) ≠ 0`. Dividing by `R` therefore plotted the physical
+  component `A_φ`, whose contours are not flux surfaces, under a docstring that called it the
+  poloidal flux. `ElectromagneticFields` 0.8.0 fixes the identical error in its own tokamak and
+  Solov'ev plots; this is the same fix, in the copy of that construction that lives here.
+
+  Only the background contours of the poloidal figures move. `is_axisymmetric_cylindrical` and the
+  chart guard are unchanged — the identification of `A₃` with `ψ` is exactly what needs the chart —
+  as are the trajectories `plot_trajectory_poloidal(R, Z, equ)` draws over them, and every number
+  this package computes. The one hand-rolled copy of the same contour, in the initial-conditions
+  example of `docs/src/initialization.md`, is corrected with it.
+
+
 ## [0.4.0] - 2026-08-08
 
 **This release is not value-preserving.** `ElectromagneticFields` 0.7.0 corrects an orientation error

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 ChargedParticlePlots = ["Makie", "LaTeXStrings"]
 
 [compat]
-ElectromagneticFields = "0.7.1"
+ElectromagneticFields = "0.8"
 GeometricEquations = "0.21"
 GeometricSolutions = "0.6"
 LaTeXStrings = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -13,7 +13,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [compat]
 CairoMakie = "0.15"
 Documenter = "1"
-ElectromagneticFields = "0.7.1"
+ElectromagneticFields = "0.8"
 GeometricIntegrators = "0.17"
 LaTeXStrings = "1"
 LinearAlgebra = "1"

--- a/docs/src/audit.md
+++ b/docs/src/audit.md
@@ -91,12 +91,17 @@ equilibria — including the toroidal `TokamakSmallNoncanonical` — are self-co
 
 ### `plot_fieldlines` is restricted to axisymmetric cylindrical equilibria
 
-It contours the poloidal flux ``\psi = R A_{\varphi}`` as `equ.A₃(0, x, y, 0) / x`, which reads the
-first two coordinates as ``(R, Z)`` and the third as the toroidal angle. That is meaningless for a
-cartesian or toroidal equilibrium, and it used to draw a plausible-looking wrong picture for them
-rather than failing. It now rejects any chart it is not valid in, and so does
+It contours the poloidal flux as `equ.A₃(0, x, y, 0)`, reading the first two coordinates as
+``(R, Z)`` and the third as the toroidal angle. That reading is meaningless for a cartesian or
+toroidal equilibrium, and it used to draw a plausible-looking wrong picture for them rather than
+failing. It now rejects any chart it is not valid in, and so does
 `plot_trajectory_poloidal(R, Z, equ)`, which forwards its equilibrium to it. The predicate is
 `is_axisymmetric_cylindrical`, decided from the coordinate ranges the field code injects.
+
+The quantity is the *covariant* component ``A_3 = R A_{\varphi} = \psi``, not the physical
+``A_{\varphi} = A_3 / R``: it is ``B \cdot \nabla A_3`` that vanishes, so only ``A_3`` has the flux
+surfaces for its contours. This contoured ``A_3 / R`` until `ElectromagneticFields` 0.8.0, which
+corrects the same error in its own equilibrium plots.
 
 ### The magnetic moment is a fixed parameter
 

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -222,7 +222,9 @@ nz = 120
 
 xgrid = LinRange( 0.5,   1.5, nr)
 ygrid = LinRange(-0.75, +0.75, nz)
-fieldlines = [A₃(0, x, y, 0.0) / x for x in xgrid, y in ygrid]
+# the poloidal flux is the covariant component A₃ = R A_φ = ψ itself, not A₃ / R — see the note on
+# `plot_fieldlines` in the audit
+fieldlines = [A₃(0, x, y, 0.0) for x in xgrid, y in ygrid]
 
 px = zeros(np)
 py = zeros(np)

--- a/ext/plots/fieldlines.jl
+++ b/ext/plots/fieldlines.jl
@@ -31,15 +31,21 @@ end
 @doc raw"""
     plot_fieldlines(equ; xrange, yrange, ngrid = (300, 200), levels = 10, kwargs...)
 
-Contour the poloidal flux ``\psi = R \, A_{\varphi}`` of `equ` over the poloidal plane, i.e. the
-projections of the magnetic field lines.
+Contour the poloidal flux ``\psi`` of `equ` over the poloidal plane, i.e. the projections of the
+magnetic field lines.
+
+The flux is the *covariant* toroidal component of the vector potential, `equ.A₃`, which the field
+code injects as ``A_3 = R \, A_{\varphi} = \psi``. Its contours are the flux surfaces, since
+``B \cdot \nabla A_3 = 0``. The physical component ``A_{\varphi} = A_3 / R`` is a different
+function, and ``B \cdot \nabla (A_3 / R) \neq 0``, so contouring it does not draw field lines — the
+same distinction `ElectromagneticFields` 0.8.0 draws in its own equilibrium plots.
 
 !!! warning "Axisymmetric cylindrical equilibria only"
-    The flux is computed as `equ.A₃(0, x, y, 0) / x`, which reads the first two coordinates as
-    ``(R, Z)`` and the third as the toroidal angle. That is meaningless for a cartesian or a
-    toroidal equilibrium, and the contours it draws there are a plausible-looking wrong picture
-    rather than an error. `plot_fieldlines` therefore rejects any `equ` that is not axisymmetric
-    cylindrical — see [`is_axisymmetric_cylindrical`](@ref).
+    `equ.A₃` is the flux only where the first two coordinates are ``(R, Z)`` and the third is the
+    toroidal angle. That identification is meaningless for a cartesian or a toroidal equilibrium,
+    and the contours it draws there are a plausible-looking wrong picture rather than an error.
+    `plot_fieldlines` therefore rejects any `equ` that is not axisymmetric cylindrical — see
+    [`is_axisymmetric_cylindrical`](@ref).
 
     This also guards [`plot_trajectory_poloidal`](@ref)`(R, Z, equ)`, which forwards its `equ` here.
     To plot a trajectory over a chart this does not cover, drop the argument and call the
@@ -48,13 +54,13 @@ projections of the magnetic field lines.
 """
 function plot_fieldlines(equ; xrange, yrange, ngrid=(300, 200), levels=10, kwargs...)
     is_axisymmetric_cylindrical(equ) || throw(ArgumentError(
-        "plot_fieldlines contours ψ = R A_φ and is only meaningful for an axisymmetric " *
+        "plot_fieldlines contours ψ = A₃ and is only meaningful for an axisymmetric " *
         "equilibrium in cylindrical coordinates (R, Z, φ); $(equ) is not one. Call " *
         "plot_trajectory_poloidal(R, Z) without the equilibrium to plot without field lines."))
 
     xgrid = LinRange(xrange..., ngrid[1])
     ygrid = LinRange(yrange..., ngrid[2])
-    fieldlines = [equ.A₃(0, xgrid[i], ygrid[j], 0.0) / xgrid[i] for i in eachindex(xgrid), j in eachindex(ygrid)];
+    fieldlines = [equ.A₃(0, xgrid[i], ygrid[j], 0.0) for i in eachindex(xgrid), j in eachindex(ygrid)];
 
     fg, ax = plot_fieldlines_figure(; xrange = xrange, yrange = yrange, kwargs...)
     contour!(ax, xgrid, ygrid, fieldlines, levels = levels, colormap = :reds)

--- a/scripts/Project.toml
+++ b/scripts/Project.toml
@@ -14,7 +14,7 @@ SimpleSolvers = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
 # it is also the one that has to bound them.
 [compat]
 CairoMakie = "0.15"
-ElectromagneticFields = "0.7.1"
+ElectromagneticFields = "0.8"
 GeometricIntegrators = "0.17"
 GeometricIntegratorsBase = "0.5.1"
 LinearAlgebra = "1"

--- a/test/plots_tests.jl
+++ b/test/plots_tests.jl
@@ -53,7 +53,7 @@ using SafeTestsets
         @test plot_fieldlines(equ; xrange = (1.0, 2.5), yrange = (-0.8, 0.8), ngrid = (40, 30)) isa Tuple
     end
 
-    # `plot_fieldlines` contours ψ = R A_φ, which is only meaningful in an axisymmetric cylindrical
+    # `plot_fieldlines` contours ψ = A₃, which is only meaningful in an axisymmetric cylindrical
     # chart. It used to accept any equilibrium and draw a plausible-looking wrong picture for the
     # cartesian and toroidal ones; it now refuses, and so does `plot_trajectory_poloidal(R, Z, equ)`,
     # which forwards its equilibrium here.


### PR DESCRIPTION
`ElectromagneticFields` 0.8.0 is a breaking release. Its break does not reach this package: it moves
plotting from Plots.jl recipes to a Makie package extension, and nothing here ever used a recipe.
Results are unchanged. One figure changes, for a reason of this package's own.

## Require `ElectromagneticFields` 0.8

Up from 0.7.1, in the root project and in the `docs/` and `scripts/` environments. `test/` still
carries no bound of its own — it reaches the suite through this package. A single minor rather than
`"0.7.1, 0.8"`, so that the allocation and timing figures in `docs/src/findings.md` mean one thing.

Three parts of the release could have reached this package, and none does:

- The **plotting break** is invisible here. The twelve `RecipesBase.@recipe` definitions upstream
  are gone, replaced by an `ElectromagneticFieldsMakieExt` extension and two new exported names,
  `plot_equilibrium` and `plot_equilibrium!`. There is not one use of Plots.jl or of an upstream
  recipe anywhere in `src/`, `ext/`, `test/`, `docs/` or `scripts/` — all plotting here is
  home-grown Makie in `ChargedParticlePlots` — and neither new name collides with the exports of
  `src/Plots.jl`. Upstream now carries the same `Makie = "0.24"` bound this package does, so the
  two extensions resolve together.
- The rest of the **exported API is unchanged**: those two names are the only additions, nothing
  was removed or renamed. `code`, `crossproduct`, every `@code*` macro, every equilibrium submodule
  and the whole injected namespace this package reads — `rangemin`, `rangemax`, `orientation`,
  `from_cartesian`, `A₁₋₃`, `b₁₋₃`, `b⃗`, `g₁₁₋₃₃`, `ḡ`, `DF̄`, `J`, `aₚ`/`bₚ`/`cₚ` — keep their names
  and their `(t, ξ₁, ξ₂, ξ₃)` / `(t, ξ)` signatures.
- The one change to the **generated code** is value-preserving. A component whose body does not
  mention the coordinates is now wrapped as `oftype(float(ξ₁), …)`, so the structurally constant
  entries take the coordinate's float type instead of the `Int` literal SymEngine emitted. That
  stops `g` and `DF` promoting at runtime — upstream measures 976 and 1072 bytes per call down to
  the 144 the 3×3 matrix actually is. `orientation()` is interpolated as a literal rather than
  emitted from a symbolic expression, so it is not wrapped and keeps returning an `Int`.

## Contour the flux itself, not the flux divided by `R`

`plot_fieldlines` computed `equ.A₃(0, x, y, 0) / x` and called the result the poloidal flux. In the
`(R, Z, φ)` chart `A₃` is the covariant toroidal component, which *is* the flux: `B · ∇A₃` vanishes,
so its contours are the flux surfaces. `A₃ / R` is the physical component `A_φ`, `B · ∇(A₃/R) ≠ 0`,
and the curves drawn were not field lines — a plausible-looking wrong picture under a docstring that
said otherwise. `ElectromagneticFields` 0.8.0 corrects the identical error in its own tokamak and
Solov'ev plots; this is that fix, in the copy of the construction that lives here.

The chart guard stays, and is as load-bearing as before: identifying `A₃` with `ψ` is exactly what
needs the first two coordinates to be `(R, Z)` and the third to be the toroidal angle. The
trajectories `plot_trajectory_poloidal(R, Z, equ)` draws over the contours do not move, and nor does
any number this package computes. `docs/src/initialization.md` carries the one hand-rolled copy of
the same contour and is corrected with it.

One consequence worth knowing, and deliberately not addressed here: `ψ` grows without bound away
from the plasma where `ψ / R` did not, so a uniform spread of `levels` now spends more of them on
the far field. The Solov'ev ITER figure in `docs/src/initialization.md` goes from about fourteen
nested contours near the axis to seven. Upstream handles this by anchoring the Solov'ev levels to
the flux on the magnetic axis; porting that heuristic into a `plot_fieldlines` that also serves the
tokamak charts, where the uniform spread is right, is a separate question. The ITER cylindrical
tokamak figure is unaffected and reads better than before.

## Verification

Against the released 0.8.0, whose tree is bit-identical to the `main` this was developed on:

- `test/runtests.jl` passes with zero failures — all 53 equilibrium modules load, and every
  recorded-value test across the five model families is unmoved, which is what establishes that the
  generated-code change is value-preserving here.
- `docs/make.jl` builds clean, with no new warnings.
- All four environments re-resolve to `ElectromagneticFields v0.8.0` from the General registry, with
  no path override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)